### PR TITLE
logging wrapper

### DIFF
--- a/mdflib-sys/src/mdf_c_wrapper.cpp
+++ b/mdflib-sys/src/mdf_c_wrapper.cpp
@@ -20,8 +20,12 @@
 #include <mdf/mdffile.h>
 #include <mdf/mdfreader.h>
 #include <mdf/mdfwriter.h>
+#include <mdf/mdflogstream.h>
+
+// #include "mdf_c_wrapper.h"
 
 using namespace mdf;
+
 
 // Export macros for different platforms
 #if defined(_WIN32)
@@ -33,6 +37,45 @@ using namespace mdf;
 #endif
 
 extern "C" {
+
+// Global function pointers for C-style callbacks
+static MdfLogFunction1 g_log_function1 = nullptr;
+static MdfLogFunction2 g_log_function2 = nullptr;
+
+// C++ wrapper for the MdfLogFunction1 callback
+void MdfLogWrapper1(const MdfLocation &location, MdfLogSeverity severity, const std::string& text) {
+    if (g_log_function1) {
+        MdfLocation c_location = {location.line, location.column, location.file.c_str(), location.function.c_str()};
+        g_log_function1(c_location, severity, text.c_str());
+    }
+}
+
+// C++ wrapper for the MdfLogFunction2 callback
+void MdfLogWrapper2(MdfLogSeverity severity, const std::string& function, const std::string& text) {
+    if (g_log_function2) {
+        g_log_function2(severity, function.c_str(), text.c_str());
+    }
+}
+
+// Function to set the C-style log function 1
+EXPORT void MdfSetLogFunction1(MdfLogFunction1 func) {
+    g_log_function1 = func;
+    if (func) {
+        MdfLogStream::SetLogFunction1(MdfLogWrapper1);
+    } else {
+        MdfLogStream::SetLogFunction1(nullptr);
+    }
+}
+
+// Function to set the C-style log function 2
+EXPORT void MdfSetLogFunction2(MdfLogFunction2 func) {
+    g_log_function2 = func;
+    if (func) {
+        MdfLogStream::SetLogFunction2(MdfLogWrapper2);
+    } else {
+        MdfLogStream::SetLogFunction2(nullptr);
+    }
+}
 
 // MdfReader functions
 EXPORT MdfReader *MdfReaderInit(const char *filename) {

--- a/mdflib-sys/src/mdf_c_wrapper.h
+++ b/mdflib-sys/src/mdf_c_wrapper.h
@@ -402,6 +402,35 @@ enum class MessageType : int {
 #define EXPORT
 #endif
 
+// MDF log severities
+enum class MdfLogSeverity : uint8_t {
+  kTrace = 0,
+  kDebug,
+  kInfo,
+  kNotice,
+  kWarning,
+  kError,
+  kCritical,
+  kAlert,
+  kEmergency
+};
+
+// MDF log location struct
+typedef struct {
+    int line;
+    int column;
+    const char* file;
+    const char* function;
+} MdfLocation;
+
+// C-compatible log function pointer types
+typedef void (*MdfLogFunction1)(const MdfLocation* location, MdfLogSeverity severity, const char* text);
+typedef void (*MdfLogFunction2)(MdfLogSeverity severity, const char* function, const char* text);
+
+// Functions to set the log callbacks
+EXPORT void MdfSetLogFunction1(MdfLogFunction1 func);
+EXPORT void MdfSetLogFunction2(MdfLogFunction2 func);
+
 // MdfReader functions
 EXPORT MdfReader* MdfReaderInit(const char* filename);
 EXPORT void MdfReaderUnInit(MdfReader* reader);

--- a/mdflib/src/lib.rs
+++ b/mdflib/src/lib.rs
@@ -29,6 +29,8 @@ pub mod header;
 pub mod reader;
 pub mod writer;
 
+pub mod log;
+
 // New MDF object modules
 pub mod attachment;
 pub mod channelarray;

--- a/mdflib/src/log.rs
+++ b/mdflib/src/log.rs
@@ -1,0 +1,76 @@
+//! Logging functionality for the mdflib crate.
+//!
+//! This module provides a safe interface to the logging capabilities of the
+//! underlying `mdflib` C++ library. It allows users to set a custom logging
+
+use mdflib_sys as ffi;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+/// Re-export of the MdfLogSeverity enum for use in the logging callback.
+pub use ffi::MdfLogSeverity;
+
+/// A struct that holds information about the source code location of a log message.
+#[derive(Debug, Clone)]
+pub struct LogLocation {
+    pub line: i32,
+    pub column: i32,
+    pub file: String,
+    pub function: String,
+}
+
+impl From<&ffi::MdfLocation> for LogLocation {
+    fn from(location: &ffi::MdfLocation) -> Self {
+        Self {
+            line: location.line,
+            column: location.column,
+            file: unsafe { CStr::from_ptr(location.file).to_string_lossy().into_owned() },
+            function: unsafe { CStr::from_ptr(location.function).to_string_lossy().into_owned() },
+        }
+    }
+}
+
+/// Type alias for the logging callback function.
+pub type LogCallback1 = extern "C" fn(location: &LogLocation, severity: MdfLogSeverity, text: &str);
+
+/// A static variable to hold the user-defined logging callback.
+static mut LOG_CALLBACK_1: Option<LogCallback1> = None;
+
+/// The C-compatible callback function that will be passed to the C++ library.
+extern "C" fn log_callback_wrapper_1(
+    location: *const ffi::MdfLocation,
+    severity: MdfLogSeverity,
+    text: *const c_char,
+) {
+    unsafe {
+        if let Some(callback) = LOG_CALLBACK_1 {
+            let rust_location = LogLocation::from(&*location);
+            let rust_text = CStr::from_ptr(text).to_string_lossy();
+            callback(&rust_location, severity, &rust_text);
+        }
+    }
+}
+
+/// Sets a custom logging function.
+///
+/// # Example
+///
+/// ```
+/// use mdflib::log::{set_log_callback_1, LogLocation, MdfLogSeverity};
+///
+/// extern "C" fn my_log_callback(location: &LogLocation, severity: MdfLogSeverity, text: &str) {
+///     println!("[{:?}] {}:{}: {}", severity, location.file, location.line, text);
+/// }
+///
+/// set_log_callback_1(Some(my_log_callback));
+/// ```
+pub fn set_log_callback_1(callback: Option<LogCallback1>) {
+    unsafe {
+        LOG_CALLBACK_1 = callback;
+        if callback.is_some() {
+            ffi::MdfSetLogFunction1(Some(log_callback_wrapper_1));
+        } else {
+            ffi::MdfSetLogFunction1(None);
+        }
+    }
+}


### PR DESCRIPTION
Can you help add logging functionality to the @mdflib code. You'll need to expose the @mdflib-sys/bundled/mdflib/src/mdflogstream.cpp functions to the wrapper, that allow me to SetLogFunction1/2. Essentially I'll want to use the log crate and define a lib log_func that switches MdfLogSeverity into log::info, log::warn, log::debug, log::trace etc. See @mdflib-sys/bundled/mdflib_test/src/testbuslogger.cpp as an example - it prints to file. Ideally the user of the module will be able to define the log_func themselves. For my examples and tests, I'll use the log crate.     