### PR TITLE
Runner for macOS and Windows and fixes for builds on these platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,8 @@ jobs:
               # Use GitHub Actions' pre-installed vcpkg
               # VCPKG_INSTALLATION_ROOT is set by GitHub Actions
               echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
-              "$VCPKG_INSTALLATION_ROOT/vcpkg" install zlib:x64-windows-static expat:x64-windows-static
+              # Use static-md triplet: static libraries with dynamic CRT (matches Rust default)
+              "$VCPKG_INSTALLATION_ROOT/vcpkg" install zlib:x64-windows-static-md expat:x64-windows-static-md
               rustup target add ${{ matrix.job.target }}
               ;;
             *-windows-gnu)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,9 @@ jobs:
               ;;
             *-windows-msvc)
               # Use GitHub Actions' pre-installed vcpkg
+              # VCPKG_INSTALLATION_ROOT is set by GitHub Actions
               echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
-              vcpkg install zlib:x64-windows-static expat:x64-windows-static
+              "$VCPKG_INSTALLATION_ROOT/vcpkg" install zlib:x64-windows-static expat:x64-windows-static
               rustup target add ${{ matrix.job.target }}
               ;;
             *-windows-gnu)
@@ -122,7 +123,7 @@ jobs:
               choco install make -y
               # Install dependencies using vcpkg for MinGW
               echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
-              vcpkg install zlib:x64-mingw-static expat:x64-mingw-static
+              "$VCPKG_INSTALLATION_ROOT/vcpkg" install zlib:x64-mingw-static expat:x64-mingw-static
               rustup target add ${{ matrix.job.target }}
               ;;
             *)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
   build-matrix:
     name: build-${{ matrix.job.os }}-${{ matrix.job.target }}
     runs-on: ${{ matrix.job.os }}
-    needs: [check]
+    needs: [build-test]
     strategy:
       fail-fast: false
       matrix:
@@ -131,9 +131,9 @@ jobs:
       - name: Test
         id: test
         shell: bash
-        run: cargo test --workspace --verbose --locked
+        run: cargo test --workspace --verbose --locked --exclude mf4-candump
 
       - name: Build release
         id: build
         shell: bash
-        run: cargo build --workspace --verbose --locked
+        run: cargo build --workspace --verbose --locked --exclude mf4-candump

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: main
   pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
   check:
@@ -13,15 +13,14 @@ jobs:
       CARGO_TERM_COLOR: always
     runs-on: ubuntu-latest
     steps:
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           submodules: recursive
+
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        id: format
+        shell: bash
+        run: cargo fmt -- --check
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
@@ -33,10 +32,10 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           submodules: recursive
-      - uses: actions/cache@v4
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v4
         with:
           path: |
             ~/.cargo/registry/index/
@@ -45,12 +44,96 @@ jobs:
             ~/.cargo/bin/cargo-deb
             target/
           key: cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - name: Build
-        run: cargo build --workspace --all-features --verbose
+      - name: Rustup update and version
+        shell: bash
+        run: |
+          rustup update
+          rustup --version
 
       - name: Run tests
-        run: cargo test --workspace --all-features --verbose
+        run: cargo test --workspace --all-features --verbose --locked
+
+      - name: Build
+        run: cargo build --workspace --verbose --locked
+
+  build-matrix:
+    name: build-${{ matrix.job.os }}-${{ matrix.job.target }}
+    runs-on: ${{ matrix.job.os }}
+    needs: [check]
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          # default features for all targets
+          - { os: windows-latest, target: x86_64-pc-windows-gnu, feature-flags: ""  }
+          - { os: macos-latest, target: aarch64-apple-darwin, feature-flags: ""  }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          submodules: recursive
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ~/.cargo/bin/cargo-deb
+            target/
+          key: ${{ matrix.job.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Rustup update and version
+        shell: bash
+        run: |
+          rustup update
+          rustup --version
+
+      - name: Install target and dependencies
+        shell: bash
+        run: |
+          case ${{ matrix.job.target }} in
+            *-apple-darwin)
+              brew install cmake expat zlib
+              rustup target add ${{ matrix.job.target }}
+              ;;
+            *-musl)
+              sudo apt-get update
+              sudo apt-get -y install musl-tools musl-dev
+              # Install cmake and build essentials
+              sudo apt-get -y install cmake build-essential
+              # For musl, we need to build static libraries or use existing .a files
+              # The -dev packages provide both .so and .a files
+              sudo apt-get -y install libexpat1-dev zlib1g-dev
+              # Create symlinks in musl lib directory for static libraries
+              sudo mkdir -p /usr/lib/x86_64-linux-musl
+              sudo ln -sf /usr/lib/x86_64-linux-gnu/libz.a /usr/lib/x86_64-linux-musl/libz.a || true
+              sudo ln -sf /usr/lib/x86_64-linux-gnu/libexpat.a /usr/lib/x86_64-linux-musl/libexpat.a || true
+              rustup target add ${{ matrix.job.target }}
+              ;;
+            *-windows-gnu)
+              choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
+              choco install mingw -y
+              choco install make -y
+              rustup target add ${{ matrix.job.target }}
+              ;;
+            *)
+              rustup target add ${{ matrix.job.target }}
+              ;;
+          esac
+
+      - name: Configure musl C++ compiler
+        if: contains(matrix.job.target, 'musl')
+        shell: bash
+        run: |
+          echo "CC_x86_64_unknown_linux_musl=musl-gcc" >> $GITHUB_ENV
+          echo "CXX_x86_64_unknown_linux_musl=g++" >> $GITHUB_ENV
+          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> $GITHUB_ENV
+
+      - name: Test
+        id: test
+        shell: bash
+        run: cargo test --workspace --verbose --locked
+
+      - name: Build release
+        id: build
+        shell: bash
+        run: cargo build --workspace --verbose --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       matrix:
         job:
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, flags: "" }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-musl, flags: "--exclude mf4-candump" }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, flags: "--exclude mf4-candump" }
           # - { os: windows-latest, target: x86_64-pc-windows-gnu, flags: "--exclude mf4-candump" }
           - { os: macos-latest, target: aarch64-apple-darwin, flags: "--exclude mf4-candump" }
@@ -69,18 +70,30 @@ jobs:
               ;;
             *-musl)
               sudo apt-get update
-              sudo apt-get -y install musl-tools musl-dev
-              # Install cmake and build essentials
-              sudo apt-get -y install cmake build-essential
-              # For musl, we need to build static libraries or use existing .a files
-              # The -dev packages provide both .so and .a files
+              sudo apt-get -y install musl-tools musl-dev cmake build-essential
               sudo apt-get -y install libexpat1-dev zlib1g-dev
-              # Create symlinks in musl lib directory for static libraries
+
+              # Create a musl-aware C++ compiler wrapper.
+              # Plain g++ uses glibc headers, which reference glibc-specific symbols
+              # (e.g. __isoc23_strtoull) that don't exist in musl.  This wrapper
+              # uses -nostdinc to remove glibc headers and explicitly adds the C++
+              # standard library headers + musl C headers in the correct order so
+              # that #include_next from <cstdlib> finds musl's <stdlib.h>.
+              GCC_VER=$(g++ -dumpversion | cut -d. -f1)
+              {
+                echo '#!/bin/sh'
+                echo "exec g++ \"\$@\" -nostdinc -isystem /usr/include/c++/$GCC_VER -isystem /usr/include/x86_64-linux-gnu/c++/$GCC_VER -isystem /usr/include/c++/$GCC_VER/backward -isystem /usr/lib/gcc/x86_64-linux-gnu/$GCC_VER/include -isystem /usr/include/x86_64-linux-musl"
+              } | sudo tee /usr/local/bin/musl-g++ >/dev/null
+              sudo chmod +x /usr/local/bin/musl-g++
+
+              # Symlink static libraries into the musl sysroot
               sudo mkdir -p /usr/lib/x86_64-linux-musl
               sudo ln -sf /usr/lib/x86_64-linux-gnu/libz.a /usr/lib/x86_64-linux-musl/libz.a || true
               sudo ln -sf /usr/lib/x86_64-linux-gnu/libexpat.a /usr/lib/x86_64-linux-musl/libexpat.a || true
+              sudo ln -sf "$(g++ -print-file-name=libstdc++.a)" /usr/lib/x86_64-linux-musl/libstdc++.a || true
+
               echo "CC_x86_64_unknown_linux_musl=musl-gcc" >> $GITHUB_ENV
-              echo "CXX_x86_64_unknown_linux_musl=g++" >> $GITHUB_ENV
+              echo "CXX_x86_64_unknown_linux_musl=musl-g++" >> $GITHUB_ENV
               echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> $GITHUB_ENV
               rustup target add ${{ matrix.job.target }}
               ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
   build-matrix:
     name: build-${{ matrix.job.os }}-${{ matrix.job.target }}
     runs-on: ${{ matrix.job.os }}
-    needs: [build-test]
+    needs: [check]
     strategy:
       fail-fast: false
       matrix:
@@ -127,6 +127,10 @@ jobs:
           echo "CC_x86_64_unknown_linux_musl=musl-gcc" >> $GITHUB_ENV
           echo "CXX_x86_64_unknown_linux_musl=g++" >> $GITHUB_ENV
           echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> $GITHUB_ENV
+
+      - name: Add MinGW to PATH
+        if: contains(matrix.job.target, '-windows-gnu')
+        run: echo "C:\tools\mingw64\bin" >> $GITHUB_PATH
 
       - name: Test
         id: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,14 @@ jobs:
               sudo ln -sf /usr/lib/x86_64-linux-gnu/libexpat.a /usr/lib/x86_64-linux-musl/libexpat.a || true
               sudo ln -sf "$(g++ -print-file-name=libstdc++.a)" /usr/lib/x86_64-linux-musl/libstdc++.a || true
 
+              # Symlink zlib/expat headers into the musl include directory so
+              # CMake finds them without adding -I/usr/include (which would
+              # pull in glibc headers that conflict with musl).
+              sudo ln -sf /usr/include/zlib.h /usr/include/x86_64-linux-musl/zlib.h || true
+              sudo ln -sf /usr/include/zconf.h /usr/include/x86_64-linux-musl/zconf.h || true
+              sudo ln -sf /usr/include/expat.h /usr/include/x86_64-linux-musl/expat.h || true
+              sudo ln -sf /usr/include/expat_external.h /usr/include/x86_64-linux-musl/expat_external.h || true
+
               echo "CC_x86_64_unknown_linux_musl=musl-gcc" >> $GITHUB_ENV
               echo "CXX_x86_64_unknown_linux_musl=musl-g++" >> $GITHUB_ENV
               echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
       matrix:
         job:
           # default features for all targets
+          - { os: windows-latest, target: x86_64-pc-windows-msvc, feature-flags: ""  }
           - { os: windows-latest, target: x86_64-pc-windows-gnu, feature-flags: ""  }
           - { os: macos-latest, target: aarch64-apple-darwin, feature-flags: ""  }
     steps:
@@ -109,16 +110,19 @@ jobs:
               sudo ln -sf /usr/lib/x86_64-linux-gnu/libexpat.a /usr/lib/x86_64-linux-musl/libexpat.a || true
               rustup target add ${{ matrix.job.target }}
               ;;
+            *-windows-msvc)
+              # Use GitHub Actions' pre-installed vcpkg
+              echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
+              vcpkg install zlib:x64-windows-static expat:x64-windows-static
+              rustup target add ${{ matrix.job.target }}
+              ;;
             *-windows-gnu)
               choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
               choco install mingw -y
               choco install make -y
               # Install dependencies using vcpkg for MinGW
-              git clone https://github.com/microsoft/vcpkg.git C:/vcpkg || true
-              cd C:/vcpkg
-              ./bootstrap-vcpkg.bat
-              ./vcpkg install zlib:x64-mingw-static expat:x64-mingw-static
-              echo "VCPKG_ROOT=C:/vcpkg" >> $GITHUB_ENV
+              echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
+              vcpkg install zlib:x64-mingw-static expat:x64-mingw-static
               rustup target add ${{ matrix.job.target }}
               ;;
             *)
@@ -141,9 +145,9 @@ jobs:
       - name: Test
         id: test
         shell: bash
-        run: cargo test --workspace --verbose --locked --exclude mf4-candump
+        run: cargo test --workspace --verbose --locked --exclude mf4-candump --target ${{ matrix.job.target }}
 
       - name: Build release
         id: build
         shell: bash
-        run: cargo build --workspace --verbose --locked --exclude mf4-candump
+        run: cargo build --workspace --verbose --locked --exclude mf4-candump --target ${{ matrix.job.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
   build-matrix:
     name: build-${{ matrix.job.os }}-${{ matrix.job.target }}
     runs-on: ${{ matrix.job.os }}
-    needs: [check]
+    # needs: [check]
     strategy:
       fail-fast: false
       matrix:
@@ -113,6 +113,12 @@ jobs:
               choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
               choco install mingw -y
               choco install make -y
+              # Install dependencies using vcpkg for MinGW
+              git clone https://github.com/microsoft/vcpkg.git C:/vcpkg || true
+              cd C:/vcpkg
+              ./bootstrap-vcpkg.bat
+              ./vcpkg install zlib:x64-mingw-static expat:x64-mingw-static
+              echo "VCPKG_ROOT=C:/vcpkg" >> $GITHUB_ENV
               rustup target add ${{ matrix.job.target }}
               ;;
             *)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
       matrix:
         job:
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, flags: "" }
-          - { os: ubuntu-latest, target: x86_64-unknown-linux-musl, flags: "--exclude mf4-candump" }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, flags: "--exclude mf4-candump" }
+          # doesn't really work...
           # - { os: windows-latest, target: x86_64-pc-windows-gnu, flags: "--exclude mf4-candump" }
           - { os: macos-latest, target: aarch64-apple-darwin, flags: "--exclude mf4-candump" }
     steps:
@@ -66,43 +66,6 @@ jobs:
           case ${{ matrix.job.target }} in
             *-apple-darwin)
               brew install cmake expat zlib
-              rustup target add ${{ matrix.job.target }}
-              ;;
-            *-musl)
-              sudo apt-get update
-              sudo apt-get -y install musl-tools musl-dev cmake build-essential
-              sudo apt-get -y install libexpat1-dev zlib1g-dev
-
-              # Create a musl-aware C++ compiler wrapper.
-              # Plain g++ uses glibc headers, which reference glibc-specific symbols
-              # (e.g. __isoc23_strtoull) that don't exist in musl.  This wrapper
-              # uses -nostdinc to remove glibc headers and explicitly adds the C++
-              # standard library headers + musl C headers in the correct order so
-              # that #include_next from <cstdlib> finds musl's <stdlib.h>.
-              GCC_VER=$(g++ -dumpversion | cut -d. -f1)
-              {
-                echo '#!/bin/sh'
-                echo "exec g++ \"\$@\" -nostdinc -isystem /usr/include/c++/$GCC_VER -isystem /usr/include/x86_64-linux-gnu/c++/$GCC_VER -isystem /usr/include/c++/$GCC_VER/backward -isystem /usr/lib/gcc/x86_64-linux-gnu/$GCC_VER/include -isystem /usr/include/x86_64-linux-musl"
-              } | sudo tee /usr/local/bin/musl-g++ >/dev/null
-              sudo chmod +x /usr/local/bin/musl-g++
-
-              # Symlink static libraries into the musl sysroot
-              sudo mkdir -p /usr/lib/x86_64-linux-musl
-              sudo ln -sf /usr/lib/x86_64-linux-gnu/libz.a /usr/lib/x86_64-linux-musl/libz.a || true
-              sudo ln -sf /usr/lib/x86_64-linux-gnu/libexpat.a /usr/lib/x86_64-linux-musl/libexpat.a || true
-              sudo ln -sf "$(g++ -print-file-name=libstdc++.a)" /usr/lib/x86_64-linux-musl/libstdc++.a || true
-
-              # Symlink zlib/expat headers into the musl include directory so
-              # CMake finds them without adding -I/usr/include (which would
-              # pull in glibc headers that conflict with musl).
-              sudo ln -sf /usr/include/zlib.h /usr/include/x86_64-linux-musl/zlib.h || true
-              sudo ln -sf /usr/include/zconf.h /usr/include/x86_64-linux-musl/zconf.h || true
-              sudo ln -sf /usr/include/expat.h /usr/include/x86_64-linux-musl/expat.h || true
-              sudo ln -sf /usr/include/expat_external.h /usr/include/x86_64-linux-musl/expat_external.h || true
-
-              echo "CC_x86_64_unknown_linux_musl=musl-gcc" >> $GITHUB_ENV
-              echo "CXX_x86_64_unknown_linux_musl=musl-g++" >> $GITHUB_ENV
-              echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> $GITHUB_ENV
               rustup target add ${{ matrix.job.target }}
               ;;
             *-windows-msvc)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,49 +25,20 @@ jobs:
       - name: Run clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-  build-test:
-    runs-on: ubuntu-latest
-    needs: [check]
-    env:
-      CARGO_TERM_COLOR: always
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-        with:
-          submodules: recursive
-      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/.cargo/bin/cargo-deb
-            target/
-          key: cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Rustup update and version
-        shell: bash
-        run: |
-          rustup update
-          rustup --version
-
-      - name: Run tests
-        run: cargo test --workspace --all-features --verbose --locked
-
-      - name: Build
-        run: cargo build --workspace --verbose --locked
-
   build-matrix:
     name: build-${{ matrix.job.os }}-${{ matrix.job.target }}
     runs-on: ${{ matrix.job.os }}
     # needs: [check]
+    env:
+      CARGO_TERM_COLOR: always
     strategy:
       fail-fast: false
       matrix:
         job:
-          # default features for all targets
-          - { os: windows-latest, target: x86_64-pc-windows-msvc, feature-flags: ""  }
-          - { os: windows-latest, target: x86_64-pc-windows-gnu, feature-flags: ""  }
-          - { os: macos-latest, target: aarch64-apple-darwin, feature-flags: ""  }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, flags: "" }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc, flags: "--exclude mf4-candump" }
+          # - { os: windows-latest, target: x86_64-pc-windows-gnu, flags: "--exclude mf4-candump" }
+          - { os: macos-latest, target: aarch64-apple-darwin, flags: "--exclude mf4-candump" }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
@@ -108,6 +79,9 @@ jobs:
               sudo mkdir -p /usr/lib/x86_64-linux-musl
               sudo ln -sf /usr/lib/x86_64-linux-gnu/libz.a /usr/lib/x86_64-linux-musl/libz.a || true
               sudo ln -sf /usr/lib/x86_64-linux-gnu/libexpat.a /usr/lib/x86_64-linux-musl/libexpat.a || true
+              echo "CC_x86_64_unknown_linux_musl=musl-gcc" >> $GITHUB_ENV
+              echo "CXX_x86_64_unknown_linux_musl=g++" >> $GITHUB_ENV
+              echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> $GITHUB_ENV
               rustup target add ${{ matrix.job.target }}
               ;;
             *-windows-msvc)
@@ -124,31 +98,22 @@ jobs:
               # Install dependencies using vcpkg for MinGW
               echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
               "$VCPKG_INSTALLATION_ROOT/vcpkg" install zlib:x64-mingw-static expat:x64-mingw-static
+              echo "C:\tools\mingw64\bin" >> $GITHUB_PATH
               rustup target add ${{ matrix.job.target }}
               ;;
             *)
+              # The -dev packages provide both .so and .a files
+              sudo apt-get -y install libexpat1-dev zlib1g-dev
               rustup target add ${{ matrix.job.target }}
               ;;
           esac
 
-      - name: Configure musl C++ compiler
-        if: contains(matrix.job.target, 'musl')
-        shell: bash
-        run: |
-          echo "CC_x86_64_unknown_linux_musl=musl-gcc" >> $GITHUB_ENV
-          echo "CXX_x86_64_unknown_linux_musl=g++" >> $GITHUB_ENV
-          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> $GITHUB_ENV
-
-      - name: Add MinGW to PATH
-        if: contains(matrix.job.target, '-windows-gnu')
-        run: echo "C:\tools\mingw64\bin" >> $GITHUB_PATH
-
       - name: Test
         id: test
         shell: bash
-        run: cargo test --workspace --verbose --locked --exclude mf4-candump --target ${{ matrix.job.target }}
+        run: cargo test --workspace --verbose --locked --target ${{ matrix.job.target }} ${{ matrix.job.flags }}
 
-      - name: Build release
+      - name: Build
         id: build
         shell: bash
-        run: cargo build --workspace --verbose --locked --exclude mf4-candump --target ${{ matrix.job.target }}
+        run: cargo build --workspace --verbose --locked --target ${{ matrix.job.target }} ${{ matrix.job.flags }}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,43 @@ It was also an experiement for me using bindgen and Copilot agent to write some 
 
 You can install these dependencies using your system's package manager.
 
+### Platform-Specific Notes
+
+#### Windows
+
+On Windows, you have two options:
+
+1. **MSVC toolchain (Recommended)**: Requires Visual Studio 2017 or later with C++ support. Use vcpkg to install dependencies:
+   ```bash
+   vcpkg install zlib:x64-windows expat:x64-windows
+   set VCPKG_ROOT=C:\path\to\vcpkg
+   cargo build
+   ```
+
+2. **GNU toolchain (MinGW)**: Requires MinGW-w64 and dependencies. Use vcpkg with MinGW triplets:
+   ```bash
+   vcpkg install zlib:x64-mingw-static expat:x64-mingw-static
+   set VCPKG_ROOT=C:\path\to\vcpkg
+   rustup target add x86_64-pc-windows-gnu
+   cargo build --target x86_64-pc-windows-gnu
+   ```
+
+#### Linux
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install cmake build-essential libexpat1-dev zlib1g-dev
+
+# Fedora/RHEL
+sudo dnf install cmake gcc-c++ expat-devel zlib-devel
+```
+
+#### macOS
+
+```bash
+brew install cmake expat zlib
+```
+
 ## Usage
 
 Review the [mdflib documentation](https://ihedvall.github.io/mdflib/), the 'mdflib/examples/' and 'mdflib/tests/' directories in this repository.

--- a/mdflib-sys/build.rs
+++ b/mdflib-sys/build.rs
@@ -311,23 +311,40 @@ fn add_platform_dependency_hints(cmake_config: &mut Command) {
         // For Windows with vcpkg, try to find the dependencies
         if let Ok(vcpkg_root) = env::var("VCPKG_ROOT") {
             let vcpkg_path = PathBuf::from(&vcpkg_root);
-            let triplet = if target.contains("x86_64") {
-                "x64-mingw-static"
+            let triplet = if target.contains("msvc") {
+                if target.contains("x86_64") {
+                    "x64-windows-static"
+                } else {
+                    "x86-windows-static"
+                }
             } else {
-                "x86-mingw-static"
+                // MinGW
+                if target.contains("x86_64") {
+                    "x64-mingw-static"
+                } else {
+                    "x86-mingw-static"
+                }
             };
             
             let vcpkg_installed = vcpkg_path.join("installed").join(triplet);
             if vcpkg_installed.exists() {
                 cmake_config.arg(format!("-DCMAKE_PREFIX_PATH={}", vcpkg_installed.display()));
-                cmake_config.arg(format!("-DCMAKE_TOOLCHAIN_FILE={}", 
-                    vcpkg_path.join("scripts").join("buildsystems").join("vcpkg.cmake").display()));
+            }
+            
+            // Always set the toolchain file for vcpkg
+            let toolchain_file = vcpkg_path.join("scripts").join("buildsystems").join("vcpkg.cmake");
+            if toolchain_file.exists() {
+                cmake_config.arg(format!("-DCMAKE_TOOLCHAIN_FILE={}", toolchain_file.display()));
+                cmake_config.arg(format!("-DVCPKG_TARGET_TRIPLET={}", triplet));
             }
         }
     }
 }
 
 fn setup_bundled_linking(install_dir: &Path) {
+    let target = env::var("TARGET").unwrap_or_default();
+    
+    // Add library search paths
     let lib_dir = install_dir.join("lib");
     if lib_dir.exists() {
         println!("cargo:rustc-link-search=native={}", lib_dir.display());
@@ -337,6 +354,18 @@ fn setup_bundled_linking(install_dir: &Path) {
             "cargo:rustc-link-search=native={}",
             install_dir.join("lib64").display()
         );
+    }
+    
+    // For MSVC, libraries might be in Release or Debug subdirectories
+    if target.contains("msvc") {
+        let lib_release = lib_dir.join("Release");
+        let lib_debug = lib_dir.join("Debug");
+        if lib_release.exists() {
+            println!("cargo:rustc-link-search=native={}", lib_release.display());
+        }
+        if lib_debug.exists() {
+            println!("cargo:rustc-link-search=native={}", lib_debug.display());
+        }
     }
 
     // Link the static libraries in the correct order

--- a/mdflib-sys/build.rs
+++ b/mdflib-sys/build.rs
@@ -57,6 +57,25 @@ fn get_vcpkg_config() -> Option<(PathBuf, String)> {
     Some((vcpkg_root, triplet))
 }
 
+/// Search the vcpkg lib directory for a library whose name contains `base_name`
+/// (case-insensitive). Returns the stem (filename without `.lib`) if found.
+/// This handles vcpkg's CRT-suffix naming, e.g. `libexpatMD.lib` for the
+/// `x64-windows-static-md` triplet.
+fn find_vcpkg_lib(base_name: &str) -> Option<String> {
+    let (vcpkg_root, triplet) = get_vcpkg_config()?;
+    let lib_dir = vcpkg_root.join("installed").join(&triplet).join("lib");
+    let lower = base_name.to_lowercase();
+    for entry in std::fs::read_dir(&lib_dir).ok()? {
+        let entry = entry.ok()?;
+        let fname = entry.file_name();
+        let name = fname.to_string_lossy();
+        if name.to_lowercase().contains(&lower) && name.ends_with(".lib") {
+            return Some(name.trim_end_matches(".lib").to_string());
+        }
+    }
+    None
+}
+
 /// Apply platform-appropriate C++ compiler flags to a cc::Build.
 fn apply_cpp_flags(build: &mut cc::Build) {
     if is_msvc() {
@@ -121,10 +140,7 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
         if let Some((vcpkg_root, triplet)) = get_vcpkg_config() {
             let toolchain = vcpkg_root.join("scripts/buildsystems/vcpkg.cmake");
             if toolchain.exists() {
-                cmake_config.arg(format!(
-                    "-DCMAKE_TOOLCHAIN_FILE={}",
-                    toolchain.display()
-                ));
+                cmake_config.arg(format!("-DCMAKE_TOOLCHAIN_FILE={}", toolchain.display()));
                 cmake_config.arg(format!("-DVCPKG_TARGET_TRIPLET={triplet}"));
                 // Use pre-installed packages rather than manifest mode so that
                 // the bundled vcpkg.json doesn't trigger a redundant install.
@@ -210,8 +226,12 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
 fn setup_dependencies() {
     println!("cargo:rerun-if-env-changed=PKG_CONFIG_PATH");
     if is_msvc() {
-        setup_dependency("zlib", "zlib");
-        setup_dependency("expat", "libexpat");
+        // On MSVC, vcpkg library names may carry a CRT-linkage suffix.
+        // e.g. expat → libexpatMD.lib (dynamic CRT) or libexpatMT.lib (static CRT).
+        let zlib_name = find_vcpkg_lib("zlib").unwrap_or_else(|| "zlib".to_string());
+        let expat_name = find_vcpkg_lib("expat").unwrap_or_else(|| "libexpat".to_string());
+        setup_dependency("zlib", &zlib_name);
+        setup_dependency("expat", &expat_name);
     } else {
         setup_dependency("zlib", "z");
         setup_dependency("expat", "expat");
@@ -365,9 +385,7 @@ fn setup_bundled_linking(install_dir: &Path) {
 
 fn setup_system_linking(_manifest_dir: &Path) {
     let mut cc_build = cc::Build::new();
-    cc_build
-        .cpp(true)
-        .file("src/mdf_c_wrapper.cpp");
+    cc_build.cpp(true).file("src/mdf_c_wrapper.cpp");
     apply_cpp_flags(&mut cc_build);
 
     // Try to find system-installed mdflib using pkg-config

--- a/mdflib-sys/build.rs
+++ b/mdflib-sys/build.rs
@@ -239,24 +239,39 @@ fn setup_dependency(name: &str, fallback_name: &str) {
     println!("cargo:rerun-if-env-changed={upper_name}_LIBRARY");
     println!("cargo:rerun-if-env-changed={upper_name}_INCLUDE_DIR");
 
-    // Determine if we should use static linking (for musl targets)
     let target = env::var("TARGET").unwrap_or_default();
     let is_musl = target.contains("musl");
-    let link_type = if is_musl { "static" } else { "dylib" };
+    let is_windows = target.contains("windows");
+    
+    // Determine link type based on target
+    let link_type = if is_musl || (is_windows && target.contains("static")) {
+        "static"
+    } else if is_windows {
+        // On Windows, vcpkg provides static libraries with -static triplets
+        if env::var("VCPKG_ROOT").is_ok() {
+            "static"
+        } else {
+            "dylib"
+        }
+    } else {
+        "dylib"
+    };
 
-    // Try pkg-config first
-    let mut pkg_config = pkg_config::Config::new();
-    if is_musl {
-        pkg_config.statik(true);
-    }
-    if pkg_config.probe(name).is_ok() {
-        println!("Found {name} via pkg-config");
-        return;
+    // Try pkg-config first (works on Linux/macOS)
+    if !is_windows {
+        let mut pkg_config = pkg_config::Config::new();
+        if is_musl {
+            pkg_config.statik(true);
+        }
+        if pkg_config.probe(name).is_ok() {
+            println!("cargo:warning=Found {name} via pkg-config");
+            return;
+        }
     }
 
-    // Then try environment variables
+    // Try environment variables
     if let Ok(lib_path_str) = env::var(format!("{upper_name}_LIBRARY")) {
-        println!("Found {name} via {upper_name}_LIBRARY environment variable");
+        println!("cargo:warning=Found {name} via {upper_name}_LIBRARY environment variable");
         let lib_path = PathBuf::from(&lib_path_str);
         if let Some(lib_dir) = lib_path.parent() {
             println!("cargo:rustc-link-search=native={}", lib_dir.display());
@@ -267,6 +282,43 @@ fn setup_dependency(name: &str, fallback_name: &str) {
             println!("cargo:rustc-link-lib={link_type}={clean_name}");
         }
         return;
+    }
+
+    // Try vcpkg on Windows
+    if is_windows {
+        if let Ok(vcpkg_root) = env::var("VCPKG_ROOT") {
+            let vcpkg_path = PathBuf::from(&vcpkg_root);
+            let triplet = if target.contains("msvc") {
+                if target.contains("x86_64") {
+                    "x64-windows-static"
+                } else {
+                    "x86-windows-static"
+                }
+            } else {
+                // MinGW
+                if target.contains("x86_64") {
+                    "x64-mingw-static"
+                } else {
+                    "x86-mingw-static"
+                }
+            };
+            
+            let vcpkg_lib_dir = vcpkg_path.join("installed").join(triplet).join("lib");
+            if vcpkg_lib_dir.exists() {
+                println!("cargo:rustc-link-search=native={}", vcpkg_lib_dir.display());
+                
+                // Determine the actual library name in vcpkg
+                let lib_name = if name == "zlib" {
+                    if target.contains("msvc") { "zlib" } else { "z" }
+                } else {
+                    fallback_name
+                };
+                
+                println!("cargo:rustc-link-lib=static={}", lib_name);
+                println!("cargo:warning=Found {name} via vcpkg at {}", vcpkg_lib_dir.display());
+                return;
+            }
+        }
     }
 
     // For musl, try to find static libraries in standard locations
@@ -283,7 +335,7 @@ fn setup_dependency(name: &str, fallback_name: &str) {
             if lib_path.exists() {
                 println!("cargo:rustc-link-search=native={}", search_path.display());
                 println!("cargo:rustc-link-lib=static={fallback_name}");
-                println!("Found {name} static library at {}", lib_path.display());
+                println!("cargo:warning=Found {name} static library at {}", lib_path.display());
                 return;
             }
         }

--- a/mdflib-sys/build.rs
+++ b/mdflib-sys/build.rs
@@ -22,11 +22,51 @@ fn main() {
     println!("cargo:rerun-if-changed=bundled");
     println!("cargo:rerun-if-changed=src/mdf_c_wrapper.h");
     println!("cargo:rerun-if-changed=src/mdf_c_wrapper.cpp");
+    println!("cargo:rerun-if-env-changed=VCPKG_ROOT");
+    println!("cargo:rerun-if-env-changed=VCPKG_DEFAULT_TRIPLET");
+    println!("cargo:rerun-if-env-changed=CMAKE_GENERATOR");
 
     println!(
         "cargo:warning=TARGET: {}",
         env::var("TARGET").unwrap_or_else(|_| "unknown".to_string())
     );
+}
+
+fn is_msvc() -> bool {
+    cfg!(target_os = "windows") && cfg!(target_env = "msvc")
+}
+
+/// Returns (vcpkg_root, triplet) if VCPKG_ROOT is set and exists.
+/// Default triplet is `x64-windows-static-md` (static libs, dynamic CRT) to match
+/// Rust's default MSVC CRT linkage. Override with `VCPKG_DEFAULT_TRIPLET` env var.
+fn get_vcpkg_config() -> Option<(PathBuf, String)> {
+    let vcpkg_root = PathBuf::from(env::var("VCPKG_ROOT").ok()?);
+    if !vcpkg_root.exists() {
+        return None;
+    }
+
+    let triplet = env::var("VCPKG_DEFAULT_TRIPLET").unwrap_or_else(|_| {
+        let arch = if cfg!(target_arch = "x86_64") {
+            "x64"
+        } else {
+            "x86"
+        };
+        format!("{arch}-windows-static-md")
+    });
+
+    Some((vcpkg_root, triplet))
+}
+
+/// Apply platform-appropriate C++ compiler flags to a cc::Build.
+fn apply_cpp_flags(build: &mut cc::Build) {
+    if is_msvc() {
+        build
+            .flag("/std:c++17")
+            .define("_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS", None)
+            .define("_CRT_SECURE_NO_WARNINGS", None);
+    } else {
+        build.flag("-std=c++17").flag("-Wno-overloaded-virtual");
+    }
 }
 
 fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
@@ -64,12 +104,32 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
         .arg("-DCMAKE_CXX_STANDARD=17");
 
     // Platform-specific CMake settings
-    if cfg!(target_os = "windows") && cfg!(target_env = "msvc") {
-        cmake_config.arg("-G").arg("Visual Studio 16 2019");
-        if cfg!(target_arch = "x86_64") {
-            cmake_config.arg("-A").arg("x64");
-        } else if cfg!(target_arch = "x86") {
-            cmake_config.arg("-A").arg("Win32");
+    if is_msvc() {
+        // Don't hardcode a Visual Studio version — let CMake auto-detect the
+        // installed version. The -A flag is only valid for VS generators, so
+        // skip it when the user has overridden CMAKE_GENERATOR to something
+        // else (e.g. Ninja).
+        if env::var("CMAKE_GENERATOR").map_or(true, |g| g.contains("Visual Studio")) {
+            if cfg!(target_arch = "x86_64") {
+                cmake_config.arg("-A").arg("x64");
+            } else if cfg!(target_arch = "x86") {
+                cmake_config.arg("-A").arg("Win32");
+            }
+        }
+
+        // Use vcpkg toolchain if available for automatic dependency resolution
+        if let Some((vcpkg_root, triplet)) = get_vcpkg_config() {
+            let toolchain = vcpkg_root.join("scripts/buildsystems/vcpkg.cmake");
+            if toolchain.exists() {
+                cmake_config.arg(format!(
+                    "-DCMAKE_TOOLCHAIN_FILE={}",
+                    toolchain.display()
+                ));
+                cmake_config.arg(format!("-DVCPKG_TARGET_TRIPLET={triplet}"));
+                // Use pre-installed packages rather than manifest mode so that
+                // the bundled vcpkg.json doesn't trigger a redundant install.
+                cmake_config.arg("-DVCPKG_MANIFEST_MODE=OFF");
+            }
         }
     } else {
         cmake_config.arg("-G").arg("Unix Makefiles");
@@ -116,14 +176,25 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
     }
 
     // Build the C wrapper
-    cc::Build::new()
+    let mut cc_build = cc::Build::new();
+    cc_build
         .cpp(true)
         .file("src/mdf_c_wrapper.cpp")
         .include(install_dir.join("include"))
-        .include(bundled_dir.join("include"))
-        .flag("-Wno-overloaded-virtual")
-        .flag("-std=c++17")
-        .compile("mdf_c_wrapper");
+        .include(bundled_dir.join("include"));
+    apply_cpp_flags(&mut cc_build);
+
+    // On MSVC with vcpkg, add vcpkg include path for dependency headers
+    if is_msvc() {
+        if let Some((vcpkg_root, triplet)) = get_vcpkg_config() {
+            let vcpkg_include = vcpkg_root.join("installed").join(&triplet).join("include");
+            if vcpkg_include.exists() {
+                cc_build.include(&vcpkg_include);
+            }
+        }
+    }
+
+    cc_build.compile("mdf_c_wrapper");
 
     // Set up linking
     setup_bundled_linking(&install_dir);
@@ -131,8 +202,13 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
 
 fn setup_dependencies() {
     println!("cargo:rerun-if-env-changed=PKG_CONFIG_PATH");
-    setup_dependency("zlib", "z");
-    setup_dependency("expat", "expat");
+    if is_msvc() {
+        setup_dependency("zlib", "zlib");
+        setup_dependency("expat", "libexpat");
+    } else {
+        setup_dependency("zlib", "z");
+        setup_dependency("expat", "expat");
+    }
 }
 
 fn setup_dependency(name: &str, fallback_name: &str) {
@@ -235,6 +311,17 @@ fn setup_bundled_linking(install_dir: &Path) {
         );
     }
 
+    // On Windows with vcpkg, add vcpkg lib directory so the linker can find
+    // zlib.lib / libexpat.lib that were installed by vcpkg.
+    if is_msvc() {
+        if let Some((vcpkg_root, triplet)) = get_vcpkg_config() {
+            let vcpkg_lib = vcpkg_root.join("installed").join(&triplet).join("lib");
+            if vcpkg_lib.exists() {
+                println!("cargo:rustc-link-search=native={}", vcpkg_lib.display());
+            }
+        }
+    }
+
     // Link the static libraries in the correct order
     println!("cargo:rustc-link-lib=static=mdf_c_wrapper");
     println!("cargo:rustc-link-lib=static=mdf");
@@ -247,7 +334,7 @@ fn setup_bundled_linking(install_dir: &Path) {
         println!("cargo:rustc-link-lib=dylib=user32");
         println!("cargo:rustc-link-lib=dylib=kernel32");
         println!("cargo:rustc-link-lib=dylib=ws2_32");
-        println!("cargo:rustc-link-lib=dylib=advapi2");
+        println!("cargo:rustc-link-lib=dylib=advapi32");
         println!("cargo:rustc-link-lib=dylib=shell32");
         println!("cargo:rustc-link-lib=dylib=ole32");
     } else if cfg!(target_os = "linux") {
@@ -266,9 +353,8 @@ fn setup_system_linking(_manifest_dir: &Path) {
     let mut cc_build = cc::Build::new();
     cc_build
         .cpp(true)
-        .file("src/mdf_c_wrapper.cpp")
-        .flag("-Wno-overloaded-virtual")
-        .flag("-std=c++17");
+        .file("src/mdf_c_wrapper.cpp");
+    apply_cpp_flags(&mut cc_build);
 
     // Try to find system-installed mdflib using pkg-config
     if let Ok(library) = pkg_config::Config::new()
@@ -299,14 +385,25 @@ fn setup_system_linking(_manifest_dir: &Path) {
             cc_build.include("/usr/local/include");
             cc_build.include("/opt/homebrew/include");
         } else if cfg!(target_os = "windows") {
-            println!("cargo:rustc-link-lib=dylib=stdc++");
             println!("cargo:rustc-link-lib=dylib=user32");
             println!("cargo:rustc-link-lib=dylib=kernel32");
             println!("cargo:rustc-link-lib=dylib=ws2_32");
-            println!("cargo:rustc-link-lib=dylib=advapi2");
+            println!("cargo:rustc-link-lib=dylib=advapi32");
             println!("cargo:rustc-link-lib=dylib=shell32");
             println!("cargo:rustc-link-lib=dylib=ole32");
             cc_build.include("C:/Program Files/mdflib/include");
+
+            // Add vcpkg include/lib paths if available
+            if let Some((vcpkg_root, triplet)) = get_vcpkg_config() {
+                let vcpkg_include = vcpkg_root.join("installed").join(&triplet).join("include");
+                let vcpkg_lib = vcpkg_root.join("installed").join(&triplet).join("lib");
+                if vcpkg_include.exists() {
+                    cc_build.include(&vcpkg_include);
+                }
+                if vcpkg_lib.exists() {
+                    println!("cargo:rustc-link-search=native={}", vcpkg_lib.display());
+                }
+            }
         }
     }
 

--- a/mdflib-sys/build.rs
+++ b/mdflib-sys/build.rs
@@ -182,6 +182,13 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
         .file("src/mdf_c_wrapper.cpp")
         .include(install_dir.join("include"))
         .include(bundled_dir.join("include"));
+
+    // On Windows, mdflib's CMake installs headers to <prefix>/mdf/include/
+    let mdf_include = install_dir.join("mdf").join("include");
+    if mdf_include.exists() {
+        cc_build.include(&mdf_include);
+    }
+
     apply_cpp_flags(&mut cc_build);
 
     // On MSVC with vcpkg, add vcpkg include path for dependency headers
@@ -309,6 +316,13 @@ fn setup_bundled_linking(install_dir: &Path) {
             "cargo:rustc-link-search=native={}",
             install_dir.join("lib64").display()
         );
+    }
+
+    // On Windows, mdflib's CMake installs to <prefix>/mdf/lib/ rather than
+    // <prefix>/lib/. Add that path so the linker can find mdf.lib.
+    let mdf_lib_dir = install_dir.join("mdf").join("lib");
+    if mdf_lib_dir.exists() {
+        println!("cargo:rustc-link-search=native={}", mdf_lib_dir.display());
     }
 
     // On Windows with vcpkg, add vcpkg lib directory so the linker can find

--- a/mdflib-sys/build.rs
+++ b/mdflib-sys/build.rs
@@ -438,28 +438,70 @@ fn add_platform_dependency_hints(cmake_config: &mut Command) {
 
 fn setup_bundled_linking(install_dir: &Path) {
     let target = env::var("TARGET").unwrap_or_default();
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let build_dir = out_dir.join("build");
     
-    // Add library search paths
+    // Collect all possible library paths
+    let mut lib_search_paths = Vec::new();
+    
+    // Standard lib directory
     let lib_dir = install_dir.join("lib");
     if lib_dir.exists() {
-        println!("cargo:rustc-link-search=native={}", lib_dir.display());
-    }
-    if install_dir.join("lib64").exists() {
-        println!(
-            "cargo:rustc-link-search=native={}",
-            install_dir.join("lib64").display()
-        );
+        lib_search_paths.push(lib_dir.clone());
     }
     
-    // For MSVC, libraries might be in Release or Debug subdirectories
+    // lib64 variant
+    if install_dir.join("lib64").exists() {
+        lib_search_paths.push(install_dir.join("lib64"));
+    }
+    
+    // For MSVC, check multiple possible locations
     if target.contains("msvc") {
+        // Install directory subdirectories
         let lib_release = lib_dir.join("Release");
         let lib_debug = lib_dir.join("Debug");
         if lib_release.exists() {
-            println!("cargo:rustc-link-search=native={}", lib_release.display());
+            lib_search_paths.push(lib_release);
         }
         if lib_debug.exists() {
-            println!("cargo:rustc-link-search=native={}", lib_debug.display());
+            lib_search_paths.push(lib_debug);
+        }
+        
+        // Build directory (where MSVC actually puts the files)
+        let build_mdflib_release = build_dir.join("mdflib").join("Release");
+        let build_mdflib_debug = build_dir.join("mdflib").join("Debug");
+        if build_mdflib_release.exists() {
+            lib_search_paths.push(build_mdflib_release);
+        }
+        if build_mdflib_debug.exists() {
+            lib_search_paths.push(build_mdflib_debug);
+        }
+        
+        // Also try build/lib/Release for older CMake versions
+        let build_lib_release = build_dir.join("lib").join("Release");
+        let build_lib_debug = build_dir.join("lib").join("Debug");
+        if build_lib_release.exists() {
+            lib_search_paths.push(build_lib_release);
+        }
+        if build_lib_debug.exists() {
+            lib_search_paths.push(build_lib_debug);
+        }
+    }
+    
+    // Add all search paths and emit warnings for debugging
+    for path in &lib_search_paths {
+        println!("cargo:rustc-link-search=native={}", path.display());
+        
+        // List what's actually in this directory for debugging
+        if let Ok(entries) = std::fs::read_dir(path) {
+            let files: Vec<String> = entries
+                .filter_map(|e| e.ok())
+                .filter(|e| e.path().extension().map_or(false, |ext| ext == "lib" || ext == "a"))
+                .map(|e| e.file_name().to_string_lossy().to_string())
+                .collect();
+            if !files.is_empty() {
+                println!("cargo:warning=Libraries in {}: {}", path.display(), files.join(", "));
+            }
         }
     }
 

--- a/mdflib-sys/build.rs
+++ b/mdflib-sys/build.rs
@@ -29,43 +29,6 @@ fn main() {
     );
 }
 
-fn apply_mingw_patches(bundled_dir: &Path) {
-    use std::fs;
-    
-    // Patch blockproperty.h to add missing #include <cstdint>
-    // This issue was fixed in upstream commit 3c49205, but we keep this patch
-    // for backwards compatibility with older submodule versions
-    let blockproperty_h = bundled_dir.join("mdflib/src/blockproperty.h");
-    if blockproperty_h.exists() {
-        let content = fs::read_to_string(&blockproperty_h)
-            .expect("Failed to read blockproperty.h");
-        
-        // Only patch if not already fixed
-        if !content.contains("#include <cstdint>") && content.contains("int64_t") {
-            let lines: Vec<&str> = content.lines().collect();
-            let mut new_content = String::new();
-            let mut patched = false;
-            
-            for (i, line) in lines.iter().enumerate() {
-                new_content.push_str(line);
-                new_content.push('\n');
-                
-                // Add #include <cstdint> after #include <string>
-                if !patched && line.contains("#include <string>") && i + 1 < lines.len() {
-                    new_content.push_str("#include <cstdint>\n");
-                    patched = true;
-                }
-            }
-            
-            if patched {
-                fs::write(&blockproperty_h, new_content)
-                    .expect("Failed to write patched blockproperty.h");
-                println!("cargo:warning=Applied MinGW patch to blockproperty.h (added cstdint include)");
-            }
-        }
-    }
-}
-
 fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
     let bundled_dir = manifest_dir.join("bundled");
     let build_dir = out_dir.join("build");
@@ -85,12 +48,6 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
         );
     }
 
-    // Apply patches for MinGW/GCC compatibility
-    let target = env::var("TARGET").unwrap_or_default();
-    if target.contains("gnu") || target.contains("mingw") {
-        apply_mingw_patches(&bundled_dir);
-    }
-
     // Configure with CMake
     let mut cmake_config = Command::new("cmake");
     cmake_config
@@ -107,61 +64,14 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
         .arg("-DCMAKE_CXX_STANDARD=17");
 
     // Platform-specific CMake settings
-    // The TARGET env var is always set by Cargo and tells us what we're compiling for
-    let target = env::var("TARGET").unwrap_or_default();
-    
-    if target.contains("windows") {
-        if target.contains("msvc") {
-            // MSVC target uses Visual Studio generator
-            // Try different Visual Studio versions
-            let vs_generators = vec![
-                ("Visual Studio 17 2022", "VS 2022"),
-                ("Visual Studio 16 2019", "VS 2019"),
-                ("Visual Studio 15 2017", "VS 2017"),
-            ];
-            
-            let mut found_vs = false;
-            for (generator, name) in &vs_generators {
-                // Test if this generator is available
-                let test_output = Command::new("cmake")
-                    .arg("-G")
-                    .arg(generator)
-                    .arg("--help")
-                    .output();
-                    
-                if test_output.map_or(false, |o| o.status.success()) {
-                    println!("cargo:warning=Using CMake generator: {} ({})", generator, name);
-                    cmake_config.arg("-G").arg(generator);
-                    found_vs = true;
-                    break;
-                }
-            }
-            
-            if !found_vs {
-                eprintln!("\nERROR: No Visual Studio installation found for MSVC target.");
-                eprintln!("Please install Visual Studio 2017 or later with C++ support.");
-                eprintln!("\nAlternatively, use the GNU toolchain:");
-                eprintln!("  rustup target add x86_64-pc-windows-gnu");
-                eprintln!("  cargo build --target x86_64-pc-windows-gnu");
-                panic!("Visual Studio not found for MSVC target");
-            }
-            
-            if target.contains("x86_64") {
-                cmake_config.arg("-A").arg("x64");
-            } else if target.contains("i686") || target.contains("i586") {
-                cmake_config.arg("-A").arg("Win32");
-            }
-        } else if target.contains("gnu") {
-            // GNU target (MinGW) uses MinGW Makefiles
-            println!("cargo:warning=Using MinGW Makefiles generator for GNU target");
-            cmake_config.arg("-G").arg("MinGW Makefiles");
-        } else {
-            // Fallback for other Windows toolchains
-            println!("cargo:warning=Unknown Windows toolchain, trying MinGW Makefiles");
-            cmake_config.arg("-G").arg("MinGW Makefiles");
+    if cfg!(target_os = "windows") && cfg!(target_env = "msvc") {
+        cmake_config.arg("-G").arg("Visual Studio 16 2019");
+        if cfg!(target_arch = "x86_64") {
+            cmake_config.arg("-A").arg("x64");
+        } else if cfg!(target_arch = "x86") {
+            cmake_config.arg("-A").arg("Win32");
         }
     } else {
-        // Unix systems use Unix Makefiles
         cmake_config.arg("-G").arg("Unix Makefiles");
     }
 
@@ -206,23 +116,14 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
     }
 
     // Build the C wrapper
-    let mut cc_build = cc::Build::new();
-    cc_build
+    cc::Build::new()
         .cpp(true)
         .file("src/mdf_c_wrapper.cpp")
         .include(install_dir.join("include"))
-        .include(bundled_dir.join("include"));
-    
-    // Add compiler-specific flags
-    let target = env::var("TARGET").unwrap_or_default();
-    if target.contains("msvc") {
-        cc_build.flag("/std:c++17");
-    } else {
-        cc_build.flag("-Wno-overloaded-virtual");
-        cc_build.flag("-std=c++17");
-    }
-    
-    cc_build.compile("mdf_c_wrapper");
+        .include(bundled_dir.join("include"))
+        .flag("-Wno-overloaded-virtual")
+        .flag("-std=c++17")
+        .compile("mdf_c_wrapper");
 
     // Set up linking
     setup_bundled_linking(&install_dir);
@@ -239,39 +140,15 @@ fn setup_dependency(name: &str, fallback_name: &str) {
     println!("cargo:rerun-if-env-changed={upper_name}_LIBRARY");
     println!("cargo:rerun-if-env-changed={upper_name}_INCLUDE_DIR");
 
-    let target = env::var("TARGET").unwrap_or_default();
-    let is_musl = target.contains("musl");
-    let is_windows = target.contains("windows");
-    
-    // Determine link type based on target
-    let link_type = if is_musl || (is_windows && target.contains("static")) {
-        "static"
-    } else if is_windows {
-        // On Windows, vcpkg provides static libraries with -static triplets
-        if env::var("VCPKG_ROOT").is_ok() {
-            "static"
-        } else {
-            "dylib"
-        }
-    } else {
-        "dylib"
-    };
-
-    // Try pkg-config first (works on Linux/macOS)
-    if !is_windows {
-        let mut pkg_config = pkg_config::Config::new();
-        if is_musl {
-            pkg_config.statik(true);
-        }
-        if pkg_config.probe(name).is_ok() {
-            println!("cargo:warning=Found {name} via pkg-config");
-            return;
-        }
+    // Try pkg-config first
+    if pkg_config::probe_library(name).is_ok() {
+        println!("Found {name} via pkg-config");
+        return;
     }
 
-    // Try environment variables
+    // Then try environment variables
     if let Ok(lib_path_str) = env::var(format!("{upper_name}_LIBRARY")) {
-        println!("cargo:warning=Found {name} via {upper_name}_LIBRARY environment variable");
+        println!("Found {name} via {upper_name}_LIBRARY environment variable");
         let lib_path = PathBuf::from(&lib_path_str);
         if let Some(lib_dir) = lib_path.parent() {
             println!("cargo:rustc-link-search=native={}", lib_dir.display());
@@ -279,73 +156,16 @@ fn setup_dependency(name: &str, fallback_name: &str) {
         if let Some(lib_name) = lib_path.file_stem() {
             let lib_name_str = lib_name.to_string_lossy();
             let clean_name = lib_name_str.strip_prefix("lib").unwrap_or(&lib_name_str);
-            println!("cargo:rustc-link-lib={link_type}={clean_name}");
+            println!("cargo:rustc-link-lib={clean_name}");
         }
         return;
-    }
-
-    // Try vcpkg on Windows
-    if is_windows {
-        if let Ok(vcpkg_root) = env::var("VCPKG_ROOT") {
-            let vcpkg_path = PathBuf::from(&vcpkg_root);
-            let triplet = if target.contains("msvc") {
-                if target.contains("x86_64") {
-                    "x64-windows-static"
-                } else {
-                    "x86-windows-static"
-                }
-            } else {
-                // MinGW
-                if target.contains("x86_64") {
-                    "x64-mingw-static"
-                } else {
-                    "x86-mingw-static"
-                }
-            };
-            
-            let vcpkg_lib_dir = vcpkg_path.join("installed").join(triplet).join("lib");
-            if vcpkg_lib_dir.exists() {
-                println!("cargo:rustc-link-search=native={}", vcpkg_lib_dir.display());
-                
-                // Determine the actual library name in vcpkg
-                let lib_name = if name == "zlib" {
-                    if target.contains("msvc") { "zlib" } else { "z" }
-                } else {
-                    fallback_name
-                };
-                
-                println!("cargo:rustc-link-lib=static={}", lib_name);
-                println!("cargo:warning=Found {name} via vcpkg at {}", vcpkg_lib_dir.display());
-                return;
-            }
-        }
-    }
-
-    // For musl, try to find static libraries in standard locations
-    if is_musl {
-        let static_lib_name = format!("lib{}.a", fallback_name);
-        let search_paths = vec![
-            PathBuf::from("/usr/lib/x86_64-linux-musl"),
-            PathBuf::from("/usr/lib"),
-            PathBuf::from("/usr/local/lib"),
-        ];
-
-        for search_path in search_paths {
-            let lib_path = search_path.join(&static_lib_name);
-            if lib_path.exists() {
-                println!("cargo:rustc-link-search=native={}", search_path.display());
-                println!("cargo:rustc-link-lib=static={fallback_name}");
-                println!("cargo:warning=Found {name} static library at {}", lib_path.display());
-                return;
-            }
-        }
     }
 
     // Finally, fallback to default system linking
     println!(
         "cargo:warning={name} not found via pkg-config or environment variables, using system defaults"
     );
-    println!("cargo:rustc-link-lib={link_type}={fallback_name}");
+    println!("cargo:rustc-link-lib={fallback_name}");
 }
 
 fn add_dependency_hints(cmake_config: &mut Command) {
@@ -373,9 +193,7 @@ fn add_single_dependency_hint(cmake_config: &mut Command, name: &str) {
 }
 
 fn add_platform_dependency_hints(cmake_config: &mut Command) {
-    let target = env::var("TARGET").unwrap_or_default();
-    
-    if target.contains("apple") || target.contains("darwin") {
+    if cfg!(target_os = "macos") {
         if Path::new("/opt/homebrew/opt/zlib").exists() {
             cmake_config.arg("-DZLIB_ROOT=/opt/homebrew/opt");
             cmake_config.arg("-DZLIB_LIBRARY=/opt/homebrew/opt/zlib/lib/libz.a");
@@ -390,7 +208,7 @@ fn add_platform_dependency_hints(cmake_config: &mut Command) {
         if Path::new("/usr/include/expat.h").exists() {
             cmake_config.arg("-DEXPAT_ROOT=/usr");
         }
-    } else if target.contains("linux") {
+    } else if cfg!(target_os = "linux") {
         // Arch Linux typically has zlib and expat in /usr/include and /usr/lib, so we can hint CMake to look there
         if Path::new("/usr/include/zlib.h").exists() {
             cmake_config.arg("-DZLIB_ROOT=/usr");
@@ -402,107 +220,19 @@ fn add_platform_dependency_hints(cmake_config: &mut Command) {
             cmake_config.arg("-DEXPAT_LIBRARY=/usr/lib/libexpat.so");
             cmake_config.arg("-DZLIB_LIBRARY=/usr/lib/libz.so");
         }
-    } else if target.contains("windows") {
-        // For Windows with vcpkg, try to find the dependencies
-        if let Ok(vcpkg_root) = env::var("VCPKG_ROOT") {
-            let vcpkg_path = PathBuf::from(&vcpkg_root);
-            let triplet = if target.contains("msvc") {
-                if target.contains("x86_64") {
-                    "x64-windows-static"
-                } else {
-                    "x86-windows-static"
-                }
-            } else {
-                // MinGW
-                if target.contains("x86_64") {
-                    "x64-mingw-static"
-                } else {
-                    "x86-mingw-static"
-                }
-            };
-            
-            let vcpkg_installed = vcpkg_path.join("installed").join(triplet);
-            if vcpkg_installed.exists() {
-                cmake_config.arg(format!("-DCMAKE_PREFIX_PATH={}", vcpkg_installed.display()));
-            }
-            
-            // Always set the toolchain file for vcpkg
-            let toolchain_file = vcpkg_path.join("scripts").join("buildsystems").join("vcpkg.cmake");
-            if toolchain_file.exists() {
-                cmake_config.arg(format!("-DCMAKE_TOOLCHAIN_FILE={}", toolchain_file.display()));
-                cmake_config.arg(format!("-DVCPKG_TARGET_TRIPLET={}", triplet));
-            }
-        }
     }
 }
 
 fn setup_bundled_linking(install_dir: &Path) {
-    let target = env::var("TARGET").unwrap_or_default();
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let build_dir = out_dir.join("build");
-    
-    // Collect all possible library paths
-    let mut lib_search_paths = Vec::new();
-    
-    // Standard lib directory
     let lib_dir = install_dir.join("lib");
     if lib_dir.exists() {
-        lib_search_paths.push(lib_dir.clone());
+        println!("cargo:rustc-link-search=native={}", lib_dir.display());
     }
-    
-    // lib64 variant
     if install_dir.join("lib64").exists() {
-        lib_search_paths.push(install_dir.join("lib64"));
-    }
-    
-    // For MSVC, check multiple possible locations
-    if target.contains("msvc") {
-        // Install directory subdirectories
-        let lib_release = lib_dir.join("Release");
-        let lib_debug = lib_dir.join("Debug");
-        if lib_release.exists() {
-            lib_search_paths.push(lib_release);
-        }
-        if lib_debug.exists() {
-            lib_search_paths.push(lib_debug);
-        }
-        
-        // Build directory (where MSVC actually puts the files)
-        let build_mdflib_release = build_dir.join("mdflib").join("Release");
-        let build_mdflib_debug = build_dir.join("mdflib").join("Debug");
-        if build_mdflib_release.exists() {
-            lib_search_paths.push(build_mdflib_release);
-        }
-        if build_mdflib_debug.exists() {
-            lib_search_paths.push(build_mdflib_debug);
-        }
-        
-        // Also try build/lib/Release for older CMake versions
-        let build_lib_release = build_dir.join("lib").join("Release");
-        let build_lib_debug = build_dir.join("lib").join("Debug");
-        if build_lib_release.exists() {
-            lib_search_paths.push(build_lib_release);
-        }
-        if build_lib_debug.exists() {
-            lib_search_paths.push(build_lib_debug);
-        }
-    }
-    
-    // Add all search paths and emit warnings for debugging
-    for path in &lib_search_paths {
-        println!("cargo:rustc-link-search=native={}", path.display());
-        
-        // List what's actually in this directory for debugging
-        if let Ok(entries) = std::fs::read_dir(path) {
-            let files: Vec<String> = entries
-                .filter_map(|e| e.ok())
-                .filter(|e| e.path().extension().map_or(false, |ext| ext == "lib" || ext == "a"))
-                .map(|e| e.file_name().to_string_lossy().to_string())
-                .collect();
-            if !files.is_empty() {
-                println!("cargo:warning=Libraries in {}: {}", path.display(), files.join(", "));
-            }
-        }
+        println!(
+            "cargo:rustc-link-search=native={}",
+            install_dir.join("lib64").display()
+        );
     }
 
     // Link the static libraries in the correct order
@@ -536,16 +266,9 @@ fn setup_system_linking(_manifest_dir: &Path) {
     let mut cc_build = cc::Build::new();
     cc_build
         .cpp(true)
-        .file("src/mdf_c_wrapper.cpp");
-    
-    // Add compiler-specific flags
-    let target = env::var("TARGET").unwrap_or_default();
-    if target.contains("msvc") {
-        cc_build.flag("/std:c++17");
-    } else {
-        cc_build.flag("-Wno-overloaded-virtual");
-        cc_build.flag("-std=c++17");
-    }
+        .file("src/mdf_c_wrapper.cpp")
+        .flag("-Wno-overloaded-virtual")
+        .flag("-std=c++17");
 
     // Try to find system-installed mdflib using pkg-config
     if let Ok(library) = pkg_config::Config::new()

--- a/mdflib-sys/build.rs
+++ b/mdflib-sys/build.rs
@@ -25,11 +25,6 @@ fn main() {
     println!("cargo:rerun-if-env-changed=VCPKG_ROOT");
     println!("cargo:rerun-if-env-changed=VCPKG_DEFAULT_TRIPLET");
     println!("cargo:rerun-if-env-changed=CMAKE_GENERATOR");
-
-    println!(
-        "cargo:warning=TARGET: {}",
-        env::var("TARGET").unwrap_or_else(|_| "unknown".to_string())
-    );
 }
 
 fn is_msvc() -> bool {
@@ -164,10 +159,7 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
             .cpp(true)
             .cargo_metadata(false)
             .get_compiler();
-        cmake_config.arg(format!(
-            "-DCMAKE_C_COMPILER={}",
-            cc_tool.path().display()
-        ));
+        cmake_config.arg(format!("-DCMAKE_C_COMPILER={}", cc_tool.path().display()));
         cmake_config.arg(format!(
             "-DCMAKE_CXX_COMPILER={}",
             cxx_tool.path().display()
@@ -266,14 +258,12 @@ fn setup_dependency(name: &str, fallback_name: &str) {
     println!("cargo:rerun-if-env-changed={upper_name}_LIBRARY");
     println!("cargo:rerun-if-env-changed={upper_name}_INCLUDE_DIR");
 
-    // For musl static builds, force static linkage
-    let static_prefix = if is_musl() { "static=" } else { "" };
+    // Try to static link
+    let static_prefix = "static=";
 
-    // Try pkg-config first
     let mut pkg = pkg_config::Config::new();
-    if is_musl() {
-        pkg.statik(true);
-    }
+    pkg.statik(true);
+
     if pkg.probe(name).is_ok() {
         println!("Found {name} via pkg-config");
         return;
@@ -342,17 +332,20 @@ fn add_platform_dependency_hints(cmake_config: &mut Command) {
             cmake_config.arg("-DEXPAT_ROOT=/usr");
         }
     } else if cfg!(target_os = "linux") {
-        if Path::new("/usr/include/zlib.h").exists() {
-            cmake_config.arg("-DZLIB_ROOT=/usr");
-        }
-        if Path::new("/usr/include/expat.h").exists() {
-            cmake_config.arg("-DEXPAT_ROOT=/usr");
-        }
-
         if is_musl() {
-            // For musl static builds, point CMake at static .a libraries.
-            // Check the musl sysroot first, then fall back to the GNU multiarch dir.
+            // For musl builds, we must NOT set ZLIB_ROOT=/usr or EXPAT_ROOT=/usr
+            // because that causes CMake to add -I/usr/include to the compiler
+            // flags, which pulls in glibc headers (e.g. features-time64.h →
+            // bits/wordsize.h) that don't exist in the musl sysroot and conflict
+            // with the musl-g++ wrapper's carefully crafted -isystem paths.
+            //
+            // Instead, set explicit INCLUDE_DIR and LIBRARY paths so CMake never
+            // adds /usr/include to the search path.
             let search_dirs = musl_lib_search_dirs();
+            if let Some(inc) = musl_include_dir() {
+                cmake_config.arg(format!("-DZLIB_INCLUDE_DIR={inc}"));
+                cmake_config.arg(format!("-DEXPAT_INCLUDE_DIR={inc}"));
+            }
             for lib_dir in &search_dirs {
                 let zlib = format!("{lib_dir}/libz.a");
                 if Path::new(&zlib).exists() {
@@ -367,9 +360,17 @@ fn add_platform_dependency_hints(cmake_config: &mut Command) {
                     break;
                 }
             }
-        } else if Path::new("/usr/lib").exists() {
-            cmake_config.arg("-DEXPAT_LIBRARY=/usr/lib/libexpat.so");
-            cmake_config.arg("-DZLIB_LIBRARY=/usr/lib/libz.so");
+        } else {
+            if Path::new("/usr/include/zlib.h").exists() {
+                cmake_config.arg("-DZLIB_ROOT=/usr");
+            }
+            if Path::new("/usr/include/expat.h").exists() {
+                cmake_config.arg("-DEXPAT_ROOT=/usr");
+            }
+            if Path::new("/usr/lib").exists() {
+                cmake_config.arg("-DEXPAT_LIBRARY=/usr/lib/libexpat.so");
+                cmake_config.arg("-DZLIB_LIBRARY=/usr/lib/libz.so");
+            }
         }
     }
 }
@@ -393,6 +394,21 @@ fn musl_lib_search_dirs() -> Vec<String> {
         }
     }
     dirs
+}
+
+/// Return the musl include directory (e.g. /usr/include/x86_64-linux-musl)
+/// where library headers (zlib.h, expat.h) should be found without pulling in
+/// glibc system headers from /usr/include.
+fn musl_include_dir() -> Option<String> {
+    if let Ok(target) = env::var("TARGET") {
+        if let Some(arch) = target.split('-').next() {
+            let musl_dir = format!("/usr/include/{arch}-linux-musl");
+            if Path::new(&musl_dir).exists() {
+                return Some(musl_dir);
+            }
+        }
+    }
+    None
 }
 
 /// Add the GCC library directory to the linker search path so that

--- a/mdflib-sys/build.rs
+++ b/mdflib-sys/build.rs
@@ -147,8 +147,17 @@ fn setup_dependency(name: &str, fallback_name: &str) {
     println!("cargo:rerun-if-env-changed={upper_name}_LIBRARY");
     println!("cargo:rerun-if-env-changed={upper_name}_INCLUDE_DIR");
 
+    // Determine if we should use static linking (for musl targets)
+    let target = env::var("TARGET").unwrap_or_default();
+    let is_musl = target.contains("musl");
+    let link_type = if is_musl { "static" } else { "dylib" };
+
     // Try pkg-config first
-    if pkg_config::probe_library(name).is_ok() {
+    let mut pkg_config = pkg_config::Config::new();
+    if is_musl {
+        pkg_config.statik(true);
+    }
+    if pkg_config.probe(name).is_ok() {
         println!("Found {name} via pkg-config");
         return;
     }
@@ -163,16 +172,36 @@ fn setup_dependency(name: &str, fallback_name: &str) {
         if let Some(lib_name) = lib_path.file_stem() {
             let lib_name_str = lib_name.to_string_lossy();
             let clean_name = lib_name_str.strip_prefix("lib").unwrap_or(&lib_name_str);
-            println!("cargo:rustc-link-lib={clean_name}");
+            println!("cargo:rustc-link-lib={link_type}={clean_name}");
         }
         return;
+    }
+
+    // For musl, try to find static libraries in standard locations
+    if is_musl {
+        let static_lib_name = format!("lib{}.a", fallback_name);
+        let search_paths = vec![
+            PathBuf::from("/usr/lib/x86_64-linux-musl"),
+            PathBuf::from("/usr/lib"),
+            PathBuf::from("/usr/local/lib"),
+        ];
+
+        for search_path in search_paths {
+            let lib_path = search_path.join(&static_lib_name);
+            if lib_path.exists() {
+                println!("cargo:rustc-link-search=native={}", search_path.display());
+                println!("cargo:rustc-link-lib=static={fallback_name}");
+                println!("Found {name} static library at {}", lib_path.display());
+                return;
+            }
+        }
     }
 
     // Finally, fallback to default system linking
     println!(
         "cargo:warning={name} not found via pkg-config or environment variables, using system defaults"
     );
-    println!("cargo:rustc-link-lib={fallback_name}");
+    println!("cargo:rustc-link-lib={link_type}={fallback_name}");
 }
 
 fn add_dependency_hints(cmake_config: &mut Command) {

--- a/mdflib-sys/build.rs
+++ b/mdflib-sys/build.rs
@@ -64,17 +64,57 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
         .arg("-DCMAKE_CXX_STANDARD=17");
 
     // Platform-specific CMake settings
-    if cfg!(target_os = "windows") {
-        if cfg!(target_env = "msvc") {
+    // The TARGET env var is always set by Cargo and tells us what we're compiling for
+    let target = env::var("TARGET").unwrap_or_default();
+    
+    if target.contains("windows") {
+        if target.contains("msvc") {
             // MSVC target uses Visual Studio generator
-            cmake_config.arg("-G").arg("Visual Studio 16 2019");
-            if cfg!(target_arch = "x86_64") {
+            // Try different Visual Studio versions
+            let vs_generators = vec![
+                ("Visual Studio 17 2022", "VS 2022"),
+                ("Visual Studio 16 2019", "VS 2019"),
+                ("Visual Studio 15 2017", "VS 2017"),
+            ];
+            
+            let mut found_vs = false;
+            for (generator, name) in &vs_generators {
+                // Test if this generator is available
+                let test_output = Command::new("cmake")
+                    .arg("-G")
+                    .arg(generator)
+                    .arg("--help")
+                    .output();
+                    
+                if test_output.map_or(false, |o| o.status.success()) {
+                    println!("cargo:warning=Using CMake generator: {} ({})", generator, name);
+                    cmake_config.arg("-G").arg(generator);
+                    found_vs = true;
+                    break;
+                }
+            }
+            
+            if !found_vs {
+                eprintln!("\nERROR: No Visual Studio installation found for MSVC target.");
+                eprintln!("Please install Visual Studio 2017 or later with C++ support.");
+                eprintln!("\nAlternatively, use the GNU toolchain:");
+                eprintln!("  rustup target add x86_64-pc-windows-gnu");
+                eprintln!("  cargo build --target x86_64-pc-windows-gnu");
+                panic!("Visual Studio not found for MSVC target");
+            }
+            
+            if target.contains("x86_64") {
                 cmake_config.arg("-A").arg("x64");
-            } else if cfg!(target_arch = "x86") {
+            } else if target.contains("i686") || target.contains("i586") {
                 cmake_config.arg("-A").arg("Win32");
             }
+        } else if target.contains("gnu") {
+            // GNU target (MinGW) uses MinGW Makefiles
+            println!("cargo:warning=Using MinGW Makefiles generator for GNU target");
+            cmake_config.arg("-G").arg("MinGW Makefiles");
         } else {
-            // GNU target (MinGW) uses Unix Makefiles or MinGW Makefiles
+            // Fallback for other Windows toolchains
+            println!("cargo:warning=Unknown Windows toolchain, trying MinGW Makefiles");
             cmake_config.arg("-G").arg("MinGW Makefiles");
         }
     } else {
@@ -123,14 +163,23 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
     }
 
     // Build the C wrapper
-    cc::Build::new()
+    let mut cc_build = cc::Build::new();
+    cc_build
         .cpp(true)
         .file("src/mdf_c_wrapper.cpp")
         .include(install_dir.join("include"))
-        .include(bundled_dir.join("include"))
-        .flag("-Wno-overloaded-virtual")
-        .flag("-std=c++17")
-        .compile("mdf_c_wrapper");
+        .include(bundled_dir.join("include"));
+    
+    // Add compiler-specific flags
+    let target = env::var("TARGET").unwrap_or_default();
+    if target.contains("msvc") {
+        cc_build.flag("/std:c++17");
+    } else {
+        cc_build.flag("-Wno-overloaded-virtual");
+        cc_build.flag("-std=c++17");
+    }
+    
+    cc_build.compile("mdf_c_wrapper");
 
     // Set up linking
     setup_bundled_linking(&install_dir);
@@ -229,7 +278,9 @@ fn add_single_dependency_hint(cmake_config: &mut Command, name: &str) {
 }
 
 fn add_platform_dependency_hints(cmake_config: &mut Command) {
-    if cfg!(target_os = "macos") {
+    let target = env::var("TARGET").unwrap_or_default();
+    
+    if target.contains("apple") || target.contains("darwin") {
         if Path::new("/opt/homebrew/opt/zlib").exists() {
             cmake_config.arg("-DZLIB_ROOT=/opt/homebrew/opt");
             cmake_config.arg("-DZLIB_LIBRARY=/opt/homebrew/opt/zlib/lib/libz.a");
@@ -244,7 +295,7 @@ fn add_platform_dependency_hints(cmake_config: &mut Command) {
         if Path::new("/usr/include/expat.h").exists() {
             cmake_config.arg("-DEXPAT_ROOT=/usr");
         }
-    } else if cfg!(target_os = "linux") {
+    } else if target.contains("linux") {
         // Arch Linux typically has zlib and expat in /usr/include and /usr/lib, so we can hint CMake to look there
         if Path::new("/usr/include/zlib.h").exists() {
             cmake_config.arg("-DZLIB_ROOT=/usr");
@@ -255,6 +306,23 @@ fn add_platform_dependency_hints(cmake_config: &mut Command) {
         if Path::new("/usr/lib").exists() {
             cmake_config.arg("-DEXPAT_LIBRARY=/usr/lib/libexpat.so");
             cmake_config.arg("-DZLIB_LIBRARY=/usr/lib/libz.so");
+        }
+    } else if target.contains("windows") {
+        // For Windows with vcpkg, try to find the dependencies
+        if let Ok(vcpkg_root) = env::var("VCPKG_ROOT") {
+            let vcpkg_path = PathBuf::from(&vcpkg_root);
+            let triplet = if target.contains("x86_64") {
+                "x64-mingw-static"
+            } else {
+                "x86-mingw-static"
+            };
+            
+            let vcpkg_installed = vcpkg_path.join("installed").join(triplet);
+            if vcpkg_installed.exists() {
+                cmake_config.arg(format!("-DCMAKE_PREFIX_PATH={}", vcpkg_installed.display()));
+                cmake_config.arg(format!("-DCMAKE_TOOLCHAIN_FILE={}", 
+                    vcpkg_path.join("scripts").join("buildsystems").join("vcpkg.cmake").display()));
+            }
         }
     }
 }
@@ -302,9 +370,16 @@ fn setup_system_linking(_manifest_dir: &Path) {
     let mut cc_build = cc::Build::new();
     cc_build
         .cpp(true)
-        .file("src/mdf_c_wrapper.cpp")
-        .flag("-Wno-overloaded-virtual")
-        .flag("-std=c++17");
+        .file("src/mdf_c_wrapper.cpp");
+    
+    // Add compiler-specific flags
+    let target = env::var("TARGET").unwrap_or_default();
+    if target.contains("msvc") {
+        cc_build.flag("/std:c++17");
+    } else {
+        cc_build.flag("-Wno-overloaded-virtual");
+        cc_build.flag("-std=c++17");
+    }
 
     // Try to find system-installed mdflib using pkg-config
     if let Ok(library) = pkg_config::Config::new()

--- a/mdflib-sys/build.rs
+++ b/mdflib-sys/build.rs
@@ -90,6 +90,96 @@ fn apply_cpp_flags(build: &mut cc::Build) {
     }
 }
 
+/// Apply all `*.patch` files from `mdflib-sys/patches/` to the bundled source
+/// tree. Uses `git apply` if available, otherwise falls back to `patch -p1`.
+/// Already-applied patches are skipped, making repeated builds idempotent.
+fn apply_patches(manifest_dir: &Path, bundled_dir: &Path) {
+    let patches_dir = manifest_dir.join("patches");
+    if !patches_dir.exists() {
+        return;
+    }
+    let mut patches: Vec<_> = std::fs::read_dir(&patches_dir)
+        .expect("Failed to read patches directory")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|ext| ext == "patch"))
+        .collect();
+    patches.sort();
+
+    for patch in &patches {
+        if try_apply_patch(bundled_dir, patch) {
+            println!(
+                "cargo:warning=Applied patch: {}",
+                patch.file_name().unwrap().to_string_lossy()
+            );
+        }
+    }
+
+    // Rebuild if patches change
+    println!("cargo:rerun-if-changed={}", patches_dir.display());
+    for patch in &patches {
+        println!("cargo:rerun-if-changed={}", patch.display());
+    }
+}
+
+/// Try to apply a single patch file. Returns true if newly applied, false if
+/// already applied. Panics on failure.
+fn try_apply_patch(bundled_dir: &Path, patch: &Path) -> bool {
+    // Try git apply first (available when building from a git checkout)
+    if let Ok(output) = Command::new("git")
+        .current_dir(bundled_dir)
+        .args(["apply", "--check", "--reverse"])
+        .arg(patch)
+        .output()
+    {
+        if output.status.success() {
+            return false; // already applied
+        }
+        // Not yet applied — try to apply
+        let apply = Command::new("git")
+            .current_dir(bundled_dir)
+            .args(["apply"])
+            .arg(patch)
+            .output()
+            .expect("Failed to run git apply");
+        if apply.status.success() {
+            return true;
+        }
+        // git apply failed — fall through to `patch` command
+    }
+
+    // Fall back to the `patch` utility (e.g. in Docker / Alpine)
+    if let Ok(output) = Command::new("patch")
+        .current_dir(bundled_dir)
+        .args(["-p1", "--forward", "-s"])
+        .stdin(std::fs::File::open(patch).expect("Failed to open patch file"))
+        .output()
+    {
+        if output.status.success() {
+            return true;
+        }
+        // Exit code 1 with --forward means already applied
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if stderr.contains("Reversed (or previously applied)")
+            || stdout.contains("Reversed (or previously applied)")
+        {
+            return false;
+        }
+        panic!(
+            "Failed to apply patch {}:\n{}{}",
+            patch.display(),
+            stdout,
+            stderr,
+        );
+    }
+
+    panic!(
+        "Neither `git` nor `patch` found. Cannot apply {}",
+        patch.display()
+    );
+}
+
 fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
     let bundled_dir = manifest_dir.join("bundled");
     let build_dir = out_dir.join("build");
@@ -108,6 +198,9 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
             bundled_dir.display()
         );
     }
+
+    // Apply patches from mdflib-sys/patches/ to the bundled source.
+    apply_patches(manifest_dir, &bundled_dir);
 
     // Configure with CMake
     let mut cmake_config = Command::new("cmake");
@@ -361,14 +454,21 @@ fn add_platform_dependency_hints(cmake_config: &mut Command) {
                 }
             }
         } else {
+            // Arch linux and some other distros put zlib and expat in /usr/
             if Path::new("/usr/include/zlib.h").exists() {
                 cmake_config.arg("-DZLIB_ROOT=/usr");
             }
             if Path::new("/usr/include/expat.h").exists() {
                 cmake_config.arg("-DEXPAT_ROOT=/usr");
             }
-            if Path::new("/usr/lib").exists() {
+            if Path::new("/usr/lib/libexpat.a").exists() {
+                cmake_config.arg("-DEXPAT_LIBRARY=/usr/lib/libexpat.a");
+            } else if Path::new("/usr/lib/libexpat.so").exists() {
                 cmake_config.arg("-DEXPAT_LIBRARY=/usr/lib/libexpat.so");
+            }
+            if Path::new("/usr/lib/libz.a").exists() {
+                cmake_config.arg("-DZLIB_LIBRARY=/usr/lib/libz.a");
+            } else if Path::new("/usr/lib/libz.so").exists() {
                 cmake_config.arg("-DZLIB_LIBRARY=/usr/lib/libz.so");
             }
         }

--- a/mdflib-sys/build.rs
+++ b/mdflib-sys/build.rs
@@ -36,6 +36,13 @@ fn is_msvc() -> bool {
     cfg!(target_os = "windows") && cfg!(target_env = "msvc")
 }
 
+/// Check whether the Cargo TARGET (not the host) uses musl libc.
+/// Uses `CARGO_CFG_TARGET_ENV` because `cfg!()` in build scripts checks the
+/// host, which is wrong when cross-compiling from glibc → musl.
+fn is_musl() -> bool {
+    env::var("CARGO_CFG_TARGET_ENV").is_ok_and(|v| v == "musl")
+}
+
 /// Returns (vcpkg_root, triplet) if VCPKG_ROOT is set and exists.
 /// Default triplet is `x64-windows-static-md` (static libs, dynamic CRT) to match
 /// Rust's default MSVC CRT linkage. Override with `VCPKG_DEFAULT_TRIPLET` env var.
@@ -149,6 +156,22 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
         }
     } else {
         cmake_config.arg("-G").arg("Unix Makefiles");
+
+        // Pass the compilers detected by the cc crate to CMake so it uses the
+        // same toolchain — essential for musl targets where CC is musl-gcc.
+        let cc_tool = cc::Build::new().cargo_metadata(false).get_compiler();
+        let cxx_tool = cc::Build::new()
+            .cpp(true)
+            .cargo_metadata(false)
+            .get_compiler();
+        cmake_config.arg(format!(
+            "-DCMAKE_C_COMPILER={}",
+            cc_tool.path().display()
+        ));
+        cmake_config.arg(format!(
+            "-DCMAKE_CXX_COMPILER={}",
+            cxx_tool.path().display()
+        ));
     }
 
     // Help CMake find dependencies
@@ -243,8 +266,15 @@ fn setup_dependency(name: &str, fallback_name: &str) {
     println!("cargo:rerun-if-env-changed={upper_name}_LIBRARY");
     println!("cargo:rerun-if-env-changed={upper_name}_INCLUDE_DIR");
 
+    // For musl static builds, force static linkage
+    let static_prefix = if is_musl() { "static=" } else { "" };
+
     // Try pkg-config first
-    if pkg_config::probe_library(name).is_ok() {
+    let mut pkg = pkg_config::Config::new();
+    if is_musl() {
+        pkg.statik(true);
+    }
+    if pkg.probe(name).is_ok() {
         println!("Found {name} via pkg-config");
         return;
     }
@@ -259,7 +289,7 @@ fn setup_dependency(name: &str, fallback_name: &str) {
         if let Some(lib_name) = lib_path.file_stem() {
             let lib_name_str = lib_name.to_string_lossy();
             let clean_name = lib_name_str.strip_prefix("lib").unwrap_or(&lib_name_str);
-            println!("cargo:rustc-link-lib={clean_name}");
+            println!("cargo:rustc-link-lib={static_prefix}{clean_name}");
         }
         return;
     }
@@ -268,7 +298,7 @@ fn setup_dependency(name: &str, fallback_name: &str) {
     println!(
         "cargo:warning={name} not found via pkg-config or environment variables, using system defaults"
     );
-    println!("cargo:rustc-link-lib={fallback_name}");
+    println!("cargo:rustc-link-lib={static_prefix}{fallback_name}");
 }
 
 fn add_dependency_hints(cmake_config: &mut Command) {
@@ -312,16 +342,75 @@ fn add_platform_dependency_hints(cmake_config: &mut Command) {
             cmake_config.arg("-DEXPAT_ROOT=/usr");
         }
     } else if cfg!(target_os = "linux") {
-        // Arch Linux typically has zlib and expat in /usr/include and /usr/lib, so we can hint CMake to look there
         if Path::new("/usr/include/zlib.h").exists() {
             cmake_config.arg("-DZLIB_ROOT=/usr");
         }
         if Path::new("/usr/include/expat.h").exists() {
             cmake_config.arg("-DEXPAT_ROOT=/usr");
         }
-        if Path::new("/usr/lib").exists() {
+
+        if is_musl() {
+            // For musl static builds, point CMake at static .a libraries.
+            // Check the musl sysroot first, then fall back to the GNU multiarch dir.
+            let search_dirs = musl_lib_search_dirs();
+            for lib_dir in &search_dirs {
+                let zlib = format!("{lib_dir}/libz.a");
+                if Path::new(&zlib).exists() {
+                    cmake_config.arg(format!("-DZLIB_LIBRARY={zlib}"));
+                    break;
+                }
+            }
+            for lib_dir in &search_dirs {
+                let expat = format!("{lib_dir}/libexpat.a");
+                if Path::new(&expat).exists() {
+                    cmake_config.arg(format!("-DEXPAT_LIBRARY={expat}"));
+                    break;
+                }
+            }
+        } else if Path::new("/usr/lib").exists() {
             cmake_config.arg("-DEXPAT_LIBRARY=/usr/lib/libexpat.so");
             cmake_config.arg("-DZLIB_LIBRARY=/usr/lib/libz.so");
+        }
+    }
+}
+
+/// Return candidate library directories for musl targets, ordered by preference.
+fn musl_lib_search_dirs() -> Vec<String> {
+    let mut dirs = Vec::new();
+    // Architecture-specific musl sysroot (e.g. /usr/lib/x86_64-linux-musl)
+    if let Ok(target) = env::var("TARGET") {
+        if let Some(arch) = target.split('-').next() {
+            let musl_dir = format!("/usr/lib/{arch}-linux-musl");
+            if Path::new(&musl_dir).exists() {
+                dirs.push(musl_dir);
+            }
+        }
+    }
+    // GNU multiarch dir (static .a files from -dev packages work with musl)
+    for dir in &["/usr/lib/x86_64-linux-gnu", "/usr/lib"] {
+        if Path::new(dir).exists() {
+            dirs.push(dir.to_string());
+        }
+    }
+    dirs
+}
+
+/// Add the GCC library directory to the linker search path so that
+/// `libstdc++.a` (and `libgcc.a` / `libgcc_eh.a`) can be found when
+/// statically linking C++ code on musl targets.
+fn add_gcc_lib_search_path() {
+    if let Ok(output) = Command::new("g++")
+        .arg("-print-file-name=libstdc++.a")
+        .output()
+    {
+        if output.status.success() {
+            let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let path = Path::new(&path_str);
+            if path.is_absolute() {
+                if let Some(dir) = path.parent() {
+                    println!("cargo:rustc-link-search=native={}", dir.display());
+                }
+            }
         }
     }
 }
@@ -372,10 +461,23 @@ fn setup_bundled_linking(install_dir: &Path) {
         println!("cargo:rustc-link-lib=dylib=shell32");
         println!("cargo:rustc-link-lib=dylib=ole32");
     } else if cfg!(target_os = "linux") {
-        println!("cargo:rustc-link-lib=dylib=stdc++");
-        println!("cargo:rustc-link-lib=dylib=m");
-        println!("cargo:rustc-link-lib=dylib=pthread");
-        println!("cargo:rustc-link-lib=dylib=dl");
+        if is_musl() {
+            // For musl, link stdc++ statically for a self-contained binary.
+            // m, pthread, and dl are part of musl's libc — no separate linking.
+            println!("cargo:rustc-link-lib=static=stdc++");
+            // Add the musl sysroot lib dir so the linker finds static .a files
+            for dir in musl_lib_search_dirs() {
+                println!("cargo:rustc-link-search=native={dir}");
+            }
+            // The musl-gcc specs may omit the GCC lib directory where
+            // libstdc++.a lives. Ask g++ for the path and add it explicitly.
+            add_gcc_lib_search_path();
+        } else {
+            println!("cargo:rustc-link-lib=dylib=stdc++");
+            println!("cargo:rustc-link-lib=dylib=m");
+            println!("cargo:rustc-link-lib=dylib=pthread");
+            println!("cargo:rustc-link-lib=dylib=dl");
+        }
     } else if cfg!(target_os = "macos") {
         println!("cargo:rustc-link-lib=dylib=c++");
         println!("cargo:rustc-link-lib=dylib=System");
@@ -404,10 +506,18 @@ fn setup_system_linking(_manifest_dir: &Path) {
         setup_dependencies();
 
         if cfg!(target_os = "linux") {
-            println!("cargo:rustc-link-lib=dylib=stdc++");
-            println!("cargo:rustc-link-lib=dylib=m");
-            println!("cargo:rustc-link-lib=dylib=pthread");
-            println!("cargo:rustc-link-lib=dylib=dl");
+            if is_musl() {
+                println!("cargo:rustc-link-lib=static=stdc++");
+                for dir in musl_lib_search_dirs() {
+                    println!("cargo:rustc-link-search=native={dir}");
+                }
+                add_gcc_lib_search_path();
+            } else {
+                println!("cargo:rustc-link-lib=dylib=stdc++");
+                println!("cargo:rustc-link-lib=dylib=m");
+                println!("cargo:rustc-link-lib=dylib=pthread");
+                println!("cargo:rustc-link-lib=dylib=dl");
+            }
             cc_build.include("/usr/local/include");
             cc_build.include("/usr/include");
         } else if cfg!(target_os = "macos") {

--- a/mdflib-sys/build.rs
+++ b/mdflib-sys/build.rs
@@ -64,14 +64,21 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
         .arg("-DCMAKE_CXX_STANDARD=17");
 
     // Platform-specific CMake settings
-    if cfg!(target_os = "windows") && cfg!(target_env = "msvc") {
-        cmake_config.arg("-G").arg("Visual Studio 16 2019");
-        if cfg!(target_arch = "x86_64") {
-            cmake_config.arg("-A").arg("x64");
-        } else if cfg!(target_arch = "x86") {
-            cmake_config.arg("-A").arg("Win32");
+    if cfg!(target_os = "windows") {
+        if cfg!(target_env = "msvc") {
+            // MSVC target uses Visual Studio generator
+            cmake_config.arg("-G").arg("Visual Studio 16 2019");
+            if cfg!(target_arch = "x86_64") {
+                cmake_config.arg("-A").arg("x64");
+            } else if cfg!(target_arch = "x86") {
+                cmake_config.arg("-A").arg("Win32");
+            }
+        } else {
+            // GNU target (MinGW) uses Unix Makefiles or MinGW Makefiles
+            cmake_config.arg("-G").arg("MinGW Makefiles");
         }
     } else {
+        // Unix systems use Unix Makefiles
         cmake_config.arg("-G").arg("Unix Makefiles");
     }
 

--- a/mdflib-sys/build.rs
+++ b/mdflib-sys/build.rs
@@ -29,6 +29,43 @@ fn main() {
     );
 }
 
+fn apply_mingw_patches(bundled_dir: &Path) {
+    use std::fs;
+    
+    // Patch blockproperty.h to add missing #include <cstdint>
+    // This issue was fixed in upstream commit 3c49205, but we keep this patch
+    // for backwards compatibility with older submodule versions
+    let blockproperty_h = bundled_dir.join("mdflib/src/blockproperty.h");
+    if blockproperty_h.exists() {
+        let content = fs::read_to_string(&blockproperty_h)
+            .expect("Failed to read blockproperty.h");
+        
+        // Only patch if not already fixed
+        if !content.contains("#include <cstdint>") && content.contains("int64_t") {
+            let lines: Vec<&str> = content.lines().collect();
+            let mut new_content = String::new();
+            let mut patched = false;
+            
+            for (i, line) in lines.iter().enumerate() {
+                new_content.push_str(line);
+                new_content.push('\n');
+                
+                // Add #include <cstdint> after #include <string>
+                if !patched && line.contains("#include <string>") && i + 1 < lines.len() {
+                    new_content.push_str("#include <cstdint>\n");
+                    patched = true;
+                }
+            }
+            
+            if patched {
+                fs::write(&blockproperty_h, new_content)
+                    .expect("Failed to write patched blockproperty.h");
+                println!("cargo:warning=Applied MinGW patch to blockproperty.h (added cstdint include)");
+            }
+        }
+    }
+}
+
 fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
     let bundled_dir = manifest_dir.join("bundled");
     let build_dir = out_dir.join("build");
@@ -46,6 +83,12 @@ fn build_bundled(out_dir: &Path, manifest_dir: &Path) {
             or download mdflib source to the bundled/ directory",
             bundled_dir.display()
         );
+    }
+
+    // Apply patches for MinGW/GCC compatibility
+    let target = env::var("TARGET").unwrap_or_default();
+    if target.contains("gnu") || target.contains("mingw") {
+        apply_mingw_patches(&bundled_dir);
     }
 
     // Configure with CMake

--- a/mdflib-sys/build.rs
+++ b/mdflib-sys/build.rs
@@ -2,6 +2,10 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// Default library directories to check for static archives when pkg-config
+/// doesn't report any `-L` paths (i.e. the libs are in the system default).
+const DEFAULT_LIB_DIRS: &[&str] = &["/usr/lib", "/usr/lib64"];
+
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
@@ -109,7 +113,7 @@ fn apply_patches(manifest_dir: &Path, bundled_dir: &Path) {
     for patch in &patches {
         if try_apply_patch(bundled_dir, patch) {
             println!(
-                "cargo:warning=Applied patch: {}",
+                "Applied patch: {}",
                 patch.file_name().unwrap().to_string_lossy()
             );
         }
@@ -347,22 +351,20 @@ fn setup_dependencies() {
 }
 
 fn setup_dependency(name: &str, fallback_name: &str) {
+    // Add /usr/lib/${target} to default dirs
+    let default_lib_dirs = if let Ok(target) = env::var("TARGET") {
+        let mut dirs = vec![format!("/usr/lib/{target}")];
+        dirs.extend(DEFAULT_LIB_DIRS.iter().map(|s| s.to_string()));
+        dirs
+    } else {
+        DEFAULT_LIB_DIRS.iter().map(|s| s.to_string()).collect()
+    };
     let upper_name = name.to_uppercase();
     println!("cargo:rerun-if-env-changed={upper_name}_LIBRARY");
     println!("cargo:rerun-if-env-changed={upper_name}_INCLUDE_DIR");
+    println!("cargo:rerun-if-env-changed={upper_name}_NO_PKG_CONFIG");
 
-    // Try to static link
-    let static_prefix = "static=";
-
-    let mut pkg = pkg_config::Config::new();
-    pkg.statik(true);
-
-    if pkg.probe(name).is_ok() {
-        println!("Found {name} via pkg-config");
-        return;
-    }
-
-    // Then try environment variables
+    // Explicit environment variable path — always preferred
     if let Ok(lib_path_str) = env::var(format!("{upper_name}_LIBRARY")) {
         println!("Found {name} via {upper_name}_LIBRARY environment variable");
         let lib_path = PathBuf::from(&lib_path_str);
@@ -372,16 +374,42 @@ fn setup_dependency(name: &str, fallback_name: &str) {
         if let Some(lib_name) = lib_path.file_stem() {
             let lib_name_str = lib_name.to_string_lossy();
             let clean_name = lib_name_str.strip_prefix("lib").unwrap_or(&lib_name_str);
-            println!("cargo:rustc-link-lib={static_prefix}{clean_name}");
+            println!("cargo:rustc-link-lib={clean_name}");
         }
         return;
     }
 
-    // Finally, fallback to default system linking
+    // Try pkg-config to find library search paths, then prefer static (.a) but fall back to dynamic (.so) if the static archive doesn't exist.
+    let mut pkg = pkg_config::Config::new();
+    pkg.statik(true);
+
+    if let Ok(lib) = pkg.probe(name) {
+        println!("Found {name} via pkg-config");
+        for dir in &lib.link_paths {
+            println!("cargo:rustc-link-search=native={}", dir.display());
+        }
+        // Check pkg-config paths and default system dirs for a static archive
+        let static_name = format!("lib{fallback_name}.a");
+        let search_dirs: Vec<&Path> = lib
+            .link_paths
+            .iter()
+            .map(|p| p.as_path())
+            .chain(default_lib_dirs.iter().map(Path::new))
+            .collect();
+        let has_static = search_dirs.iter().any(|d| d.join(&static_name).exists());
+        if has_static {
+            println!("cargo:rustc-link-lib=static={fallback_name}");
+        } else {
+            println!("cargo:rustc-link-lib=dylib={fallback_name}");
+        }
+        return;
+    }
+
+    // Fallback to default system linking (dylib — let the linker decide)
     println!(
         "cargo:warning={name} not found via pkg-config or environment variables, using system defaults"
     );
-    println!("cargo:rustc-link-lib={static_prefix}{fallback_name}");
+    println!("cargo:rustc-link-lib={fallback_name}");
 }
 
 fn add_dependency_hints(cmake_config: &mut Command) {

--- a/mdflib-sys/patches/0001-musl-compat.patch
+++ b/mdflib-sys/patches/0001-musl-compat.patch
@@ -1,0 +1,41 @@
+diff --git a/mdflib/src/blockproperty.h b/mdflib/src/blockproperty.h
+index e3ae16c..57bd809 100644
+--- a/mdflib/src/blockproperty.h
++++ b/mdflib/src/blockproperty.h
+@@ -3,6 +3,7 @@
+  * SPDX-License-Identifier: MIT
+  */
+ #pragma once
++#include <cstdint>
+ #include <string>
+ namespace mdf::detail {
+ enum class BlockItemType {
+diff --git a/mdflib/src/platform.cpp b/mdflib/src/platform.cpp
+index 2e7b9dd..6dacaea 100644
+--- a/mdflib/src/platform.cpp
++++ b/mdflib/src/platform.cpp
+@@ -31,19 +31,15 @@ int strnicmp(const char *__s1, const char *__s2, size_t __n) {
+ void strerror(int __errnum, char *__buf, size_t __buflen) {
+ #if (_WIN32)
+   strerror_s(__buf, __buflen, __errnum);
+-#elif (__APPLE__ || __FreeBSD__)
+-  int err = strerror_r(__errnum, __buf, __buflen);
+-  if (err == 0)
+-  {
+-    
+-  }
+-#elif (__CYGWIN__)
+-  strerror_r(__errnum, __buf, __buflen);
+-#else
++#elif defined(__GLIBC__) && !defined(__APPLE__)
++  // GNU-specific strerror_r returns char*
+   auto* dummy = strerror_r(__errnum, __buf, __buflen);
+   if (dummy != nullptr) {
+     strcpy(__buf, dummy);
+   }
++#else
++  // POSIX strerror_r (musl, macOS, FreeBSD, Cygwin) returns int
++  strerror_r(__errnum, __buf, __buflen);
+ #endif
+ }
+ 


### PR DESCRIPTION
Updates build.rs for Windows build. Installs dependencies for each so that build works - macOS only need these installing.

Build now tries to statically link as first preference, failing back to dynamic linking. It can be controlled with ENVs ZLIB_LIBRARY and EXPAT_LIBRARY to explicitly define libs to use; .a or .so. pkg-config [linking envs](https://docs.rs/pkg-config/latest/pkg_config/#linking) should also work.